### PR TITLE
Improve file handling

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -4,7 +4,12 @@ import GDALDataset from './gdalDataset.js';
 function open(file) {
     return callWorker('GDALOpen', [file]).then(
         function (openResult) {
-            return new GDALDataset(openResult.datasetPtr, openResult.filePath);
+            return new GDALDataset(
+                openResult.datasetPtr,
+                openResult.filePath,
+                openResult.directory,
+                openResult.filename
+            );
         },
         function (error) { throw error; }
     );

--- a/src/gdalDataset.js
+++ b/src/gdalDataset.js
@@ -1,15 +1,19 @@
 import { callWorker } from './workerCommunication.js';
 
 export default class GDALDataset {
-    constructor(datasetPtr, filePath) {
+    constructor(datasetPtr, filePath, directory, filename) {
         this.datasetPtr = datasetPtr;
         this.filePath = filePath;
+        this.directory = directory;
+        this.filename = filename;
     }
 
     close() {
-        return callWorker('GDALClose', [this.datasetPtr, this.filePath]).finally(() => {
-            this.datasetPtr = null;
-            this.filePath = null;
+        return callWorker('GDALClose', [this.datasetPtr, this.directory]).finally(() => {
+            delete this.datasetPtr;
+            delete this.filePath;
+            delete this.directory;
+            delete this.filename;
         });
     }
 

--- a/src/randomKey.js
+++ b/src/randomKey.js
@@ -1,0 +1,9 @@
+// https://stackoverflow.com/questions/10726909/random-alpha-numeric-string-in-javascript
+export default function randomKey(length = 32, chars = '0123456789abcdefghijklmnopqrstuvwxyz') {
+    let result = '';
+
+    for (let i = length; i > 0; i--) {
+        result += chars[Math.floor(Math.random() * chars.length)];
+    }
+    return result;
+}

--- a/src/worker.js
+++ b/src/worker.js
@@ -11,7 +11,7 @@ import wGDALGetRasterYSize from './wrappers/gdalGetRasterYSize.js';
 import wGDALGetProjectionRef from './wrappers/gdalGetProjectionRef.js';
 import wGDALGetGeoTransform from './wrappers/gdalGetGeoTransform.js';
 
-const TIFFPATH = '/tiffs';
+const DATASETPATH = '/datasets';
 
 let initialized = false;
 
@@ -33,11 +33,11 @@ self.Module = {
         //
         registry.GDALOpen = wGDALOpen(
             self.Module.cwrap('GDALOpen', 'number', ['string']),
-            TIFFPATH
+            DATASETPATH
         );
         registry.GDALClose = wGDALClose(
             self.Module.cwrap('GDALClose', 'number', ['number']),
-            TIFFPATH
+            DATASETPATH
         );
         registry.GDALGetRasterCount = wGDALGetRasterCount(
             self.Module.cwrap('GDALGetRasterCount', 'number', ['number'])
@@ -57,10 +57,15 @@ self.Module = {
             ])
         );
         registry.LoamFlushFS = function () {
-            FS.unmount(TIFFPATH);
+            let datasetFolders = FS.lookupPath(DATASETPATH).node.contents;
+
+            Object.values(datasetFolders).forEach(node => {
+                FS.unmount(FS.getPath(node));
+                FS.rmdir(FS.getPath(node));
+            });
             return true;
         };
-        FS.mkdir(TIFFPATH);
+        FS.mkdir(DATASETPATH);
         initialized = true;
         postMessage({ready: true});
     }

--- a/src/workerCommunication.js
+++ b/src/workerCommunication.js
@@ -1,3 +1,5 @@
+import randomKey from './randomKey.js';
+
 let messages = {};
 
 let workerPromise;
@@ -6,21 +8,6 @@ let workerPromise;
 // out where all the other scripts should be pulled from
 let _scripts = document.getElementsByTagName('script');
 const THIS_SCRIPT = _scripts[_scripts.length - 1];
-
-// https://stackoverflow.com/questions/10726909/random-alpha-numeric-string-in-javascript
-function randomKey() {
-    const length = 32;
-    const chars = (
-        '0123456789' +
-        'abcdefghijklmnopqrstuvwxzy'
-    );
-    let result = '';
-
-    for (let i = length; i > 0; i--) {
-        result += chars[Math.floor(Math.random() * chars.length)];
-    }
-    return result;
-}
 
 // Inspired by Emscripten's method for doing the same thing
 function getPathPrefix() {

--- a/src/wrappers/gdalClose.js
+++ b/src/wrappers/gdalClose.js
@@ -1,10 +1,10 @@
 /* global FS */
-export default function (GDALClose, tiffFolder) {
-    return function (datasetPtr, filePath) {
-        let result = GDALClose(datasetPtr);
-
-        FS.unmount(filePath);
-        return result;
+export default function (GDALClose) {
+    return function (datasetPtr, directory) {
+        GDALClose(datasetPtr);
+        FS.unmount(directory);
+        FS.rmdir(directory);
+        return true;
     };
 }
 

--- a/src/wrappers/gdalOpen.js
+++ b/src/wrappers/gdalOpen.js
@@ -3,12 +3,12 @@ export default function (GDALOpen, tiffFolder) {
     return function (file) {
         let filename;
 
-        if (file instanceof Blob) {
-            filename = 'geotiff.tif';
-            FS.mount(WORKERFS, { blobs: [{ name: filename, data: file }] }, tiffFolder);
-        } else if (file instanceof File) {
+        if (file instanceof File) {
             filename = file.name;
             FS.mount(WORKERFS, { files: [file] }, tiffFolder);
+        } else if (file instanceof Blob) {
+            filename = 'geotiff.tif';
+            FS.mount(WORKERFS, { blobs: [{ name: filename, data: file }] }, tiffFolder);
         }
         let filePath = tiffFolder + '/' + filename;
 

--- a/src/wrappers/gdalOpen.js
+++ b/src/wrappers/gdalOpen.js
@@ -1,20 +1,27 @@
+import randomKey from '../randomKey.js';
+
 /* global FS WORKERFS */
-export default function (GDALOpen, tiffFolder) {
+export default function (GDALOpen, rootPath) {
     return function (file) {
         let filename;
+        let directory = rootPath + '/' + randomKey();
+
+        FS.mkdir(directory);
 
         if (file instanceof File) {
             filename = file.name;
-            FS.mount(WORKERFS, { files: [file] }, tiffFolder);
+            FS.mount(WORKERFS, { files: [file] }, directory);
         } else if (file instanceof Blob) {
             filename = 'geotiff.tif';
-            FS.mount(WORKERFS, { blobs: [{ name: filename, data: file }] }, tiffFolder);
+            FS.mount(WORKERFS, { blobs: [{ name: filename, data: file }] }, directory);
         }
-        let filePath = tiffFolder + '/' + filename;
+        let filePath = directory + '/' + filename;
 
         return {
             datasetPtr: GDALOpen(filePath),
-            filePath: filePath
+            filePath: filePath,
+            directory: directory,
+            filename: filename
         };
     };
 }

--- a/test/loam.spec.js
+++ b/test/loam.spec.js
@@ -35,7 +35,7 @@ describe('Given that loam exists', () => {
                     expect(ds).to.be.an.instanceof(loam.GDALDataset);
                     expect(ds.datasetPtr).to.be.a('number', 'datasetPtr was not a number');
                     expect(ds.datasetPtr).not.to.equal(0, 'datasetPtr was 0 (null)');
-                    expect(ds.filePath).to.equal('/tiffs/geotiff.tif');
+                    expect(ds.filename).to.equal('geotiff.tif');
                 });
         });
     });
@@ -111,13 +111,15 @@ describe('Given that loam exists', () => {
 
     describe('calling close', function() {
         it('should succeed and clear the GDALDataset', function () {
-            return xhrAsPromiseBlob(tinyTifPath).then((tifBlob) => loam.open(tifBlob).then((ds) => {
-                ds.close().then((result) => {
-                    expect(result).to.equal(true);
-                    expect(ds.datasetPtr).to.be.an('undefined');
-                    expect(ds.filePath).to.be.an('undefined');
+            return xhrAsPromiseBlob(tinyTifPath).then(tifBlob => {
+                    return loam.open(tifBlob).then(ds => {
+                        return ds.close().then(result => {
+                            expect(result).to.equal(true);
+                            expect(ds.datasetPtr).to.be.an('undefined');
+                            expect(ds.filePath).to.be.an('undefined');
+                        });
+                    });
                 });
-            }));
         });
     });
 });


### PR DESCRIPTION
Fixes file handling problems exposed by attempting to integrate Loam into an Angular app. Namely:
- Checks for Files _before_ Blobs when deciding how to open files (`File` inherits from `Blob`)
- Significantly reworks the worker file handling to allow multiple datasets to be opened at once, and fixes a problem with `GDALDataset.close()` that wasn't being exposed by tests.