### PR TITLE
Add reprojection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Built libraries are placed in `lib`.
 # Basic usage
 
 ```javascript
+// Load WebAssembly and data files asynchronously. Will be called automatically by loam.open()
+// but it is often helpful for responsiveness to pre-initialize. Returns a promise.
+loam.initialize();
+
 // Assuming you have a `Blob` object from somewhere. `File` objects also work
 loam.open(blob).then((dataset) => {
   dataset.width()
@@ -23,7 +27,13 @@ loam.open(blob).then((dataset) => {
   // - transform() (returns in GDAL ordering, not affine transform ordering)
   // - wkt()
   // - count() (returns number of bands)
+  // - convert() (Takes an array of strings that match options to gdal_translate, e.g. ['-of', 'PNG'], returns dataset)
+  // - warp() (Takes an array of strings that match options to gdalwarp https://www.gdal.org/gdalwarp.html, returns dataset)
+
 });
+
+// Utility function for reprojecting points. srcSRS and destSRS must be full WKT strings.
+loam.reproject(srcSRS, destSRS, [[x, y], [x, y], ...]);
 ```
 Further examples are available in the tests.
 

--- a/src/api.js
+++ b/src/api.js
@@ -15,6 +15,13 @@ function open(file) {
     );
 }
 
+function reproject(fromCRS, toCRS, coords) {
+    var xCoords = new Float64Array(coords.map(function (pair) { return pair[0]; }));
+    var yCoords = new Float64Array(coords.map(function (pair) { return pair[1]; }));
+
+    return callWorker('LoamReproject', [fromCRS, toCRS, xCoords, yCoords]);
+}
+
 function flushFS() {
     return callWorker('LoamFlushFS', []);
 }
@@ -23,4 +30,4 @@ function initialize() {
     return initWorker();
 }
 
-export { open, flushFS, initialize };
+export { open, flushFS, initialize, reproject };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { open, flushFS, initialize } from './api.js';
+import { open, flushFS, initialize, reproject } from './api.js';
 import GDALDataset from './gdalDataset.js';
 
-export default { open, flushFS, GDALDataset, initialize };
+export default { open, flushFS, GDALDataset, initialize, reproject };

--- a/src/worker.js
+++ b/src/worker.js
@@ -12,6 +12,7 @@ import wGDALGetProjectionRef from './wrappers/gdalGetProjectionRef.js';
 import wGDALGetGeoTransform from './wrappers/gdalGetGeoTransform.js';
 import wGDALTranslate from './wrappers/gdalTranslate.js';
 import wGDALWarp from './wrappers/gdalWarp.js';
+import wReproject from './wrappers/reproject.js';
 
 const DATASETPATH = '/datasets';
 
@@ -126,6 +127,7 @@ self.Module = {
             });
             return true;
         };
+        registry.LoamReproject = wReproject;
         FS.mkdir(DATASETPATH);
         initialized = true;
         postMessage({ready: true});

--- a/src/wrappers/reproject.js
+++ b/src/wrappers/reproject.js
@@ -1,0 +1,61 @@
+/* global Module */
+export default function (srcCRSStr, destCRSStr, xCoords, yCoords) {
+    // This should never happen
+    if (xCoords.length !== yCoords.length) {
+        throw new Error('Got mismatched numbers of x and y coordinates.');
+    }
+    let OSRNewSpatialReference = Module.cwrap('OSRNewSpatialReference', 'number', ['string']);
+    let OCTNewCoordinateTransformation = Module.cwrap(
+        'OCTNewCoordinateTransformation',
+        'number',
+        ['number', 'number']
+    );
+    // Transform arrays of coordinates in-place
+    // Params are:
+    // 1. Coordinate transformation to use
+    // 2. Number of coordinates to transform
+    // 3. Array of X coordinates to transform
+    // 4. Array of Y coordinates to transform
+    // 5. Array of Z coordinates to transform
+    let OCTTransform = Module.cwrap(
+        'OCTTransform',
+        'number',
+        ['number', 'number', 'number', 'number', 'number']
+    );
+
+    let sourceSrs = OSRNewSpatialReference(srcCRSStr);
+    // Next, we also need an SRS for Lat/Lon
+    let targetSrs = OSRNewSpatialReference(destCRSStr);
+    // Now we can create a CoordinateTransformation object to transform between the two
+    let coordTransform = OCTNewCoordinateTransformation(sourceSrs, targetSrs);
+
+    // And lastly, we can transform the Xs and Ys. This requires a similar malloc process to the
+    // affine transform function above, since the coordinates are transformed in-place
+    let xCoordPtr = Module._malloc(xCoords.length * xCoords.BYTES_PER_ELEMENT);
+    let yCoordPtr = Module._malloc(yCoords.length * yCoords.BYTES_PER_ELEMENT);
+
+    // But this time we copy into the memory space from our external array
+    Module.HEAPF64.set(xCoords, xCoordPtr / xCoords.BYTES_PER_ELEMENT);
+    Module.HEAPF64.set(yCoords, yCoordPtr / yCoords.BYTES_PER_ELEMENT);
+    // Z is null in this case. This transforms in place.
+    OCTTransform(coordTransform, xCoords.length, xCoordPtr, yCoordPtr, null);
+    // Pull out the coordinates
+    let transXCoords = Array.from(Module.HEAPF64.subarray(
+        xCoordPtr / xCoords.BYTES_PER_ELEMENT,
+        xCoordPtr / xCoords.BYTES_PER_ELEMENT + xCoords.length
+    ));
+    let transYCoords = Array.from(Module.HEAPF64.subarray(
+        yCoordPtr / yCoords.BYTES_PER_ELEMENT,
+        yCoordPtr / yCoords.BYTES_PER_ELEMENT + yCoords.length
+    ));
+
+    // zip it all back up and return
+    let returnVal = transXCoords.map(function (x, i) { return [x, transYCoords[i]]; });
+
+    Module._free(xCoordPtr);
+    Module._free(yCoordPtr);
+    Module.ccall('OSRDestroySpatialReference', 'number', ['number'], [sourceSrs]);
+    Module.ccall('OSRDestroySpatialReference', 'number', ['number'], [targetSrs]);
+    Module.ccall('OCTDestroyCoordinateTransformation', 'number', ['number'], [coordTransform]);
+    return returnVal;
+}

--- a/src/wrappers/reproject.js
+++ b/src/wrappers/reproject.js
@@ -23,14 +23,14 @@ export default function (srcCRSStr, destCRSStr, xCoords, yCoords) {
         ['number', 'number', 'number', 'number', 'number']
     );
 
+    // We need SRSes for the source and destinations of our transformation
     let sourceSrs = OSRNewSpatialReference(srcCRSStr);
-    // Next, we also need an SRS for Lat/Lon
     let targetSrs = OSRNewSpatialReference(destCRSStr);
     // Now we can create a CoordinateTransformation object to transform between the two
     let coordTransform = OCTNewCoordinateTransformation(sourceSrs, targetSrs);
 
     // And lastly, we can transform the Xs and Ys. This requires a similar malloc process to the
-    // affine transform function above, since the coordinates are transformed in-place
+    // affine transform function, since the coordinates are transformed in-place
     let xCoordPtr = Module._malloc(xCoords.length * xCoords.BYTES_PER_ELEMENT);
     let yCoordPtr = Module._malloc(yCoords.length * yCoords.BYTES_PER_ELEMENT);
 
@@ -49,9 +49,10 @@ export default function (srcCRSStr, destCRSStr, xCoords, yCoords) {
         yCoordPtr / yCoords.BYTES_PER_ELEMENT + yCoords.length
     ));
 
-    // zip it all back up and return
+    // Zip it all back up
     let returnVal = transXCoords.map(function (x, i) { return [x, transYCoords[i]]; });
 
+    // Clear memory
     Module._free(xCoordPtr);
     Module._free(yCoordPtr);
     Module.ccall('OSRDestroySpatialReference', 'number', ['number'], [sourceSrs]);

--- a/test/loam.spec.js
+++ b/test/loam.spec.js
@@ -1,34 +1,36 @@
-/* global describe, it, before, expect */
+/* global describe, it, before, afterEach, expect, loam */
 const tinyTifPath = '/base/test/assets/tiny.tif';
 const invalidTifPath = 'base/test/assets/not-a-tiff.bytes';
+const epsg4326 = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]';
+const epsg3857 = 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"],AUTHORITY["EPSG","3857"]]';
 
 function xhrAsPromiseBlob(url) {
     let xhr = new XMLHttpRequest();
+
     xhr.open('GET', url);
     xhr.responseType = 'blob';
-    return new Promise(function(resolve, reject) {
-        xhr.onload = function(oEvent) {
+    return new Promise(function (resolve, reject) {
+        xhr.onload = function (oEvent) {
             resolve(xhr.response);
         };
-        xhr.onerror = function(oEvent) {
+        xhr.onerror = function (oEvent) {
             reject(oEvent);
         };
         xhr.send();
     });
 }
 
-
 describe('Given that loam exists', () => {
-    before(function() {
+    before(function () {
         this.timeout(15000);
         return loam.initialize();
     });
 
-    afterEach(function() {
+    afterEach(function () {
         return loam.flushFS();
     });
 
-    describe('calling open with a Blob', function() {
+    describe('calling open with a Blob', function () {
         it('should return a GDALDataset', () => {
             return xhrAsPromiseBlob(tinyTifPath)
                 .then((tifBlob) => loam.open(tifBlob))
@@ -43,6 +45,22 @@ describe('Given that loam exists', () => {
 
     describe('calling open with a File', function () {
         it('should return a GDALDataset');
+    });
+
+    describe('calling reproject()', function () {
+        it('should reproject points from one CRS to another', () => {
+            return loam.reproject(epsg4326, epsg3857, [
+                [-75.1652, 39.9526],
+                [44.8271, 41.7151],
+                [-47.9218, -15.8267]
+            ]).then((coords) => {
+                expect(coords).to.deep.equal([
+                    [-8367351.7893745685, 4859056.629543971],
+                    [4990129.945739155, 5118397.8827427635],
+                    [-5334630.373897098, -1784662.322609764]
+                ]);
+            });
+        });
     });
 
     describe('calling count()', function () {
@@ -102,29 +120,29 @@ describe('Given that loam exists', () => {
                 .then((tifBlob) => loam.open(tifBlob))
                 .then((ds) => ds.transform())
                 .then((transform) => {
-                        expect(transform).to.deep.equal([
-                            -8380165.213197844, 2416.6666666666665, 0,
-                            4886134.645645497, 0, -2468.75
-                        ]);
+                    expect(transform).to.deep.equal([
+                        -8380165.213197844, 2416.6666666666665, 0,
+                        4886134.645645497, 0, -2468.75
+                    ]);
                 });
         });
     });
 
-    describe('calling close', function() {
+    describe('calling close', function () {
         it('should succeed and clear the GDALDataset', function () {
             return xhrAsPromiseBlob(tinyTifPath).then(tifBlob => {
-                    return loam.open(tifBlob).then(ds => {
-                        return ds.close().then(result => {
-                            expect(result).to.deep.equal([]);
-                            expect(ds.datasetPtr).to.be.an('undefined');
-                            expect(ds.filePath).to.be.an('undefined');
-                        });
+                return loam.open(tifBlob).then(ds => {
+                    return ds.close().then(result => {
+                        expect(result).to.deep.equal([]);
+                        expect(ds.datasetPtr).to.be.an('undefined');
+                        expect(ds.filePath).to.be.an('undefined');
                     });
                 });
+            });
         });
     });
 
-    describe('calling closeAndReadBytes', function() {
+    describe('calling closeAndReadBytes', function () {
         it('should succeed and return the file contents', function () {
             return xhrAsPromiseBlob(tinyTifPath)
                 .then(tifBlob => loam.open(tifBlob))
@@ -133,7 +151,7 @@ describe('Given that loam exists', () => {
         });
     });
 
-    describe('calling convert', function() {
+    describe('calling convert', function () {
         it('should succeed and return a new Dataset with the transformed values', function () {
             return xhrAsPromiseBlob(tinyTifPath)
                 .then(tifBlob => loam.open(tifBlob))
@@ -143,7 +161,7 @@ describe('Given that loam exists', () => {
         });
     });
 
-    describe('calling warp', function() {
+    describe('calling warp', function () {
         it('should succeed and return a new Dataset that has been warped', function () {
             return xhrAsPromiseBlob(tinyTifPath)
                 .then(tifBlob => loam.open(tifBlob))
@@ -151,23 +169,23 @@ describe('Given that loam exists', () => {
                 .then(newDS => newDS.transform())
                 // Determined out-of-band by executing gdalwarp on the command line.
                 .then(transform => {
-                    expect(transform).to.deep.equal(
-                        [-75.2803049446235,
-                         0.019340471787624117,
-                         0.0,
-                         40.13881222863268,
-                         0.0,
-                         -0.019340471787624117]
-                    );
+                    expect(transform).to.deep.equal([
+                        -75.2803049446235,
+                        0.019340471787624117,
+                        0.0,
+                        40.13881222863268,
+                        0.0,
+                        -0.019340471787624117
+                    ]);
                 });
         });
     });
 
-    /******************************************
-     * Failure cases                          *
-     ******************************************/
-    describe('calling open() on an invalid file', function() {
-        it('should fail and return an error message', function() {
+    /**
+     * Failure cases
+     **/
+    describe('calling open() on an invalid file', function () {
+        it('should fail and return an error message', function () {
             return xhrAsPromiseBlob(invalidTifPath)
                 .then(garbage => loam.open(garbage))
                 .then(
@@ -181,8 +199,8 @@ describe('Given that loam exists', () => {
         });
     });
 
-    describe('calling close() on an invalid dataset', function() {
-        it('should fail and return an error message', function() {
+    describe('calling close() on an invalid dataset', function () {
+        it('should fail and return an error message', function () {
             return new loam.GDALDataset(0, 'nothing', 'nothing', 'nothing')
                 .close().then(
                     (result) => {
@@ -195,8 +213,8 @@ describe('Given that loam exists', () => {
         });
     });
 
-    describe('calling transform() on an invalid dataset', function() {
-        it('should fail and return an error message', function() {
+    describe('calling transform() on an invalid dataset', function () {
+        it('should fail and return an error message', function () {
             return new loam.GDALDataset(0, 'nothing', 'nothing', 'nothing')
                 .transform().then(
                     () => {
@@ -209,8 +227,8 @@ describe('Given that loam exists', () => {
         });
     });
 
-    describe('calling wkt on an invalid dataset', function() {
-        it('should fail and return an error message', function() {
+    describe('calling wkt on an invalid dataset', function () {
+        it('should fail and return an error message', function () {
             return new loam.GDALDataset(0, 'nothing', 'nothing', 'nothing')
                 .wkt().then(
                     () => {
@@ -223,8 +241,8 @@ describe('Given that loam exists', () => {
         });
     });
 
-    describe('calling count on an invalid dataset', function() {
-        it('should fail and return an error message', function() {
+    describe('calling count on an invalid dataset', function () {
+        it('should fail and return an error message', function () {
             return new loam.GDALDataset(0, 'nothing', 'nothing', 'nothing')
                 .count().then(
                     () => {
@@ -237,8 +255,8 @@ describe('Given that loam exists', () => {
         });
     });
 
-    describe('calling width on an invalid dataset', function() {
-        it('should fail and return an error message', function() {
+    describe('calling width on an invalid dataset', function () {
+        it('should fail and return an error message', function () {
             return new loam.GDALDataset(0, 'nothing', 'nothing', 'nothing')
                 .width().then(
                     () => {
@@ -251,8 +269,8 @@ describe('Given that loam exists', () => {
         });
     });
 
-    describe('calling height on an invalid dataset', function() {
-        it('should fail and return an error message', function() {
+    describe('calling height on an invalid dataset', function () {
+        it('should fail and return an error message', function () {
             return new loam.GDALDataset(0, 'nothing', 'nothing', 'nothing')
                 .height().then(
                     () => {
@@ -265,8 +283,8 @@ describe('Given that loam exists', () => {
         });
     });
 
-    describe('calling convert with invalid arguments', function() {
-        it('should fail and return an error message', function() {
+    describe('calling convert with invalid arguments', function () {
+        it('should fail and return an error message', function () {
             return xhrAsPromiseBlob(tinyTifPath)
                 .then(tifBlob => loam.open(tifBlob))
                 .then(ds => ds.convert(['-notreal', 'xyz%', 'oink%']))
@@ -278,14 +296,14 @@ describe('Given that loam exists', () => {
                         );
                     },
                     error => expect(error.message).to.include(
-                        "Unknown option name"
+                        'Unknown option name'
                     )
                 );
         });
     });
 
-    describe('calling warp with invalid arguments', function() {
-        it('should fail and return an error message', function() {
+    describe('calling warp with invalid arguments', function () {
+        it('should fail and return an error message', function () {
             return xhrAsPromiseBlob(tinyTifPath)
                 .then(tifBlob => loam.open(tifBlob))
                 .then(ds => ds.warp(['-s_srs', 'EPSG:Fake', '-t_srs', 'EPSG:AlsoFake']))


### PR DESCRIPTION
Adds a utility function, `loam.reproject()`, that reprojects arrays of points between two coordinate reference systems (given by WKT strings). Includes a test for this functionality. This is primarily for convenience, so that simple pages do not need to pull in a dependency like proj4js to perform reprojection.

Also applies some format linting, and updates the README to cover more of the API.

Will merge sometime after CI success.