### PR TITLE
[WIP] Specify path prefix; Add `gdalDataset.rasterize()`

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -26,8 +26,8 @@ function flushFS() {
     return callWorker('LoamFlushFS', []);
 }
 
-function initialize() {
-    return initWorker();
+function initialize(pathPrefix) {
+    return initWorker(pathPrefix);
 }
 
 export { open, flushFS, initialize, reproject };

--- a/src/gdalDataset.js
+++ b/src/gdalDataset.js
@@ -88,4 +88,18 @@ export default class GDALDataset {
             function (error) { throw error; }
         );
     }
+
+    rasterize(args) {
+        return callWorker('GDALRasterize', [this.datasetPtr, args]).then(
+            function (result) {
+                return new GDALDataset(
+                    result.datasetPtr,
+                    result.filePath,
+                    result.directory,
+                    result.filename
+                );
+            },
+            function (error) { throw error; }
+        );
+    }
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -13,6 +13,7 @@ import wGDALGetGeoTransform from './wrappers/gdalGetGeoTransform.js';
 import wGDALTranslate from './wrappers/gdalTranslate.js';
 import wGDALWarp from './wrappers/gdalWarp.js';
 import wReproject from './wrappers/reproject.js';
+import wGDALRasterize from './wrappers/gdalRasterize';
 
 const DATASETPATH = '/datasets';
 
@@ -57,7 +58,7 @@ self.Module = {
             self.Module.cwrap('CPLQuietErrorHandler', 'number', ['number'])
         );
 
-        // Then set the error handler to the quiet handler.
+        // // Then set the error handler to the quiet handler.
         self.Module.ccall('CPLSetErrorHandler', 'number', ['number'], [cplQuietFnPtr]);
 
         // Set up JS proxy functions
@@ -66,7 +67,7 @@ self.Module = {
         // C returns a pointer to a GDALDataset, we need to use 'number'.
         //
         registry.GDALOpen = wGDALOpen(
-            self.Module.cwrap('GDALOpen', 'number', ['string']),
+            self.Module.cwrap('GDALOpenEx', 'number', ['string']),
             errorHandling,
             DATASETPATH
         );
@@ -113,6 +114,17 @@ self.Module = {
                 'number', // Number of input datasets
                 'number', // GDALDatasetH * list of source datasets
                 'number', // GDALWarpAppOptions *
+                'number' // int * to use for error reporting
+            ]),
+            errorHandling,
+            DATASETPATH
+        );
+        registry.GDALRasterize = wGDALRasterize(
+            self.Module.cwrap('GDALRasterize', 'number', [
+                'string', // Destination dataset path or NULL
+                'number', // GDALDatasetH destination dataset or NULL
+                'number', // GDALDatasetH source dataset handle
+                'number', // GDALRasterizeOptions * or NULL,
                 'number' // int * to use for error reporting
             ]),
             errorHandling,

--- a/src/workerCommunication.js
+++ b/src/workerCommunication.js
@@ -18,10 +18,12 @@ function getPathPrefix() {
 }
 
 // Set up a WebWorker and an associated promise that resolves once it's ready
-function initWorker() {
+function initWorker(pathPrefix) {
+    pathPrefix = pathPrefix || getPathPrefix();
+
     if (typeof workerPromise === 'undefined') {
         workerPromise = new Promise(function (resolve, reject) {
-            let _worker = new Worker(getPathPrefix() + 'loam-worker.js');
+            let _worker = new Worker(pathPrefix + 'loam-worker.js');
 
             // The worker needs to do some initialization, and will send a message when it's ready.
             _worker.onmessage = function (msg) {

--- a/src/wrappers/gdalRasterize.js
+++ b/src/wrappers/gdalRasterize.js
@@ -1,0 +1,114 @@
+/* global Module, FS, MEMFS */
+import randomKey from '../randomKey.js';
+import guessFileExtension from '../guessFileExtension.js';
+
+export default function (GDALRasterize, errorHandling, rootPath) {
+    return function (datasetPtr, args) {
+        // So first, we need to allocate Emscripten heap space sufficient to store each string as a
+        // null-terminated C string.
+        // Because the C function signature is char **, this array of pointers is going to need to
+        // get copied into Emscripten heap space eventually, so we're going to prepare by storing
+        // the pointers as a typed array so that we can more easily copy it into heap space later.
+        let argPtrsArray = Uint32Array.from(args.map(argStr => {
+            return Module._malloc(Module.lengthBytesUTF8(argStr) + 1); // +1 for the null terminator byte
+        }).concat([0]));
+        // ^ In addition to each individual argument being null-terminated, the GDAL docs specify that
+        // GDALRasterizeOptionsNew takes its options passed in as a null-terminated array of
+        // pointers, so we have to add on a null (0) byte at the end.
+
+        // Next, we need to write each string from the JS string array into the Emscripten heap space
+        // we've allocated for it.
+        args.forEach(function (argStr, i) {
+            Module.stringToUTF8(argStr, argPtrsArray[i], Module.lengthBytesUTF8(argStr) + 1);
+        });
+
+        // Now, as mentioned above, we also need to copy the pointer array itself into heap space.
+        let argPtrsArrayPtr = Module._malloc(argPtrsArray.length * argPtrsArray.BYTES_PER_ELEMENT);
+
+        Module.HEAPU32.set(argPtrsArray, argPtrsArrayPtr / argPtrsArray.BYTES_PER_ELEMENT);
+
+        // Whew, all finished. argPtrsArrayPtr is now the address of the start of the list of
+        // pointers in Emscripten heap space. Each pointer identifies the address of the start of a
+        // parameter string, also stored in heap space. This is the direct equivalent of a char **,
+        // which is what GDALRasterizeOptionsNew requires.
+
+        let rasterizeOptionsPtr = Module.ccall('GDALRasterizeOptionsNew', 'number',
+            ['number', 'number'],
+            [argPtrsArrayPtr, null]
+        );
+
+        // Validate that the options were correct
+        let optionsErrType = errorHandling.CPLGetLastErrorType();
+
+        if (optionsErrType === errorHandling.CPLErr.CEFailure ||
+          optionsErrType === errorHandling.CPLErr.CEFatal) {
+            Module._free(argPtrsArrayPtr);
+            // Don't try to free the null terminator byte
+            argPtrsArray.subarray(0, argPtrsArray.length - 1).forEach(ptr => Module._free(ptr));
+            const message = errorHandling.CPLGetLastErrorMsg();
+
+            throw new Error(message);
+        }
+
+        // Now that we have our translate options, we need to make a file location to hold the output.
+        let directory = rootPath + '/' + randomKey();
+
+        FS.mkdir(directory);
+        // This makes it easier to remove later because we can just unmount rather than recursing
+        // through the whole directory structure.
+        FS.mount(MEMFS, {}, directory);
+        let filename = randomKey(8) + '.' + guessFileExtension(args);
+        let filePath = directory + '/' + filename;
+
+        // And then we can kick off the actual warping process.
+        // TODO: The last parameter is an int* that can be used to detect certain kinds of errors,
+        // but I'm not sure how it works yet and whether it gives the same or different information
+        // than CPLGetLastErrorType
+        // We can get some error information out of the final pbUsageError parameter, which is an
+        // int*, so malloc ourselves an int and set it to 0 (False)
+        let usageErrPtr = Module._malloc(Int32Array.BYTES_PER_ELEMENT);
+
+        Module.setValue(usageErrPtr, 0, 'i32');
+
+        let newDatasetPtr = GDALRasterize(
+            filePath, // Output
+            0, // NULL because filePath is not NULL
+            datasetPtr,
+            rasterizeOptionsPtr,
+            usageErrPtr
+        );
+
+        let errorType = errorHandling.CPLGetLastErrorType();
+        // If we ever want to use the usage error pointer:
+        // let usageErr = Module.getValue(usageErrPtr, 'i32');
+
+        // The final set of cleanup we need to do, in a function to avoid writing it twice.
+        function cleanUp() {
+            Module.ccall('GDALRasterizeOptionsFree', null, ['number'], [rasterizeOptionsPtr]);
+            Module._free(argPtrsArrayPtr);
+            Module._free(usageErrPtr);
+            // Don't try to free the null terminator byte
+            argPtrsArray.subarray(0, argPtrsArray.length - 1).forEach(ptr => Module._free(ptr));
+        }
+
+        // Check for errors; clean up and throw if error is detected
+        if (errorType === errorHandling.CPLErr.CEFailure ||
+                errorType === errorHandling.CPLErr.CEFatal) {
+            cleanUp();
+            const message = errorHandling.CPLGetLastErrorMsg();
+
+            throw new Error(message);
+        } else {
+            const result = {
+                datasetPtr: newDatasetPtr,
+                filePath: filePath,
+                directory: directory,
+                filename: filename
+            };
+
+            cleanUp();
+
+            return result;
+        }
+    };
+}

--- a/test/loam.spec.js
+++ b/test/loam.spec.js
@@ -184,20 +184,6 @@ describe('Given that loam exists', () => {
     /**
      * Failure cases
      **/
-    describe('calling open() on an invalid file', function () {
-        it('should fail and return an error message', function () {
-            return xhrAsPromiseBlob(invalidTifPath)
-                .then(garbage => loam.open(garbage))
-                .then(
-                    () => {
-                        throw new Error('GDALOpen promise should have been rejected');
-                    },
-                    error => expect(error.message).to.include(
-                        'not recognized as a supported file format'
-                    )
-                );
-        });
-    });
 
     describe('calling close() on an invalid dataset', function () {
         it('should fail and return an error message', function () {


### PR DESCRIPTION
This PR does a few things:
- adds an argument, `pathPrefix: string`, to the `loam.initialize` method to allow consumers to specify the location of the gdal-js wasm and loam-worker files
- uses `GDALOpenEx` under the hood of `loam.open()` instead of `GDALOpen` to support non-raster file types
- adds `gdalDataset.rasterize()` that wraps `GDALRasterize`

There are some remaining questions:
- are we happy with a single open method or should we introduce a separate vector open method?
- if we are happy with a single open method, can we still detect bad input?
