### PR TITLE
Validate parameters to `convert()` and `warp()`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Overview
+
+Brief description of what this PR does and why it is needed.
+
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+
+## Testing Instructions
+
+ * How to test this PR
+ * Prefer bulleted description
+ * Start after checking out this branch
+ * Include any setup required, such as bundling scripts, restarting services, etc.
+ * Include test case and expected output
+
+
+## Checklist
+
+- [ ] Add entry to CHANGELOG.md
+
+Resolves #XXX

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,7 @@
+## Upcoming release
+- Package updates to resolve security alerts
+- Validate that parameters to `warp()` and `convert()` are strings
+- Add CHANGELOG, PR template
+
+## 1.0.0-alpha.10 (2019-02-13)
+- Add `reproject()` utility function

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,0 +1,5 @@
+function isArrayAllStrings(args) {
+    return args.every(arg => typeof arg === 'string');
+}
+
+export { isArrayAllStrings };

--- a/src/wrappers/gdalTranslate.js
+++ b/src/wrappers/gdalTranslate.js
@@ -1,10 +1,14 @@
 import randomKey from '../randomKey.js';
 import guessFileExtension from '../guessFileExtension.js';
+import { isArrayAllStrings } from '../validation.js';
 
 /* global Module, FS, MEMFS */
 export default function (GDALTranslate, errorHandling, rootPath) {
     // Args is expected to be an array of strings that could function as arguments to gdal_translate
     return function (dataset, args) {
+        if (!isArrayAllStrings(args)) {
+            throw new Error('All items in the argument list must be strings');
+        }
         // So first, we need to allocate Emscripten heap space sufficient to store each string as a
         // null-terminated C string.
         // Because the C function signature is char **, this array of pointers is going to need to

--- a/src/wrappers/gdalWarp.js
+++ b/src/wrappers/gdalWarp.js
@@ -1,10 +1,14 @@
 import randomKey from '../randomKey.js';
 import guessFileExtension from '../guessFileExtension.js';
+import { isArrayAllStrings } from '../validation.js';
 
 /* global Module, FS, MEMFS */
 export default function (GDALWarp, errorHandling, rootPath) {
     // Args is expected to be an array of strings that could function as arguments to gdal_translate
     return function (dataset, args) {
+        if (!isArrayAllStrings(args)) {
+            throw new Error('All items in the argument list must be strings');
+        }
         // So first, we need to allocate Emscripten heap space sufficient to store each string as a
         // null-terminated C string.
         // Because the C function signature is char **, this array of pointers is going to need to

--- a/test/loam.spec.js
+++ b/test/loam.spec.js
@@ -320,4 +320,42 @@ describe('Given that loam exists', () => {
                 );
         });
     });
+
+    describe('calling convert with non-string arguments', function () {
+        it('should fail and return an error message', function () {
+            return xhrAsPromiseBlob(tinyTifPath)
+                .then(tifBlob => loam.open(tifBlob))
+                .then(ds => ds.convert(['-outsize', 25]))
+                .then(
+                    (result) => {
+                        throw new Error(
+                            'convert() promise should have been rejected but got ' +
+                            result + ' instead.'
+                        );
+                    },
+                    error => expect(error.message).to.include(
+                        'All items in the argument list must be strings'
+                    )
+                );
+        });
+    });
+
+    describe('calling warp with non-string arguments', function () {
+        it('should fail and return an error message', function () {
+            return xhrAsPromiseBlob(tinyTifPath)
+                .then(tifBlob => loam.open(tifBlob))
+                .then(ds => ds.warp(['-order', 2]))
+                .then(
+                    (result) => {
+                        throw new Error(
+                            'warp() promise should have been rejected but got ' +
+                            result + ' instead.'
+                        );
+                    },
+                    error => expect(error.message).to.include(
+                        'All items in the argument list must be strings'
+                    )
+                );
+        });
+    });
 });


### PR DESCRIPTION
## Overview                                                                     
                                                                                
New users frequently encounter problems when calling these two functions if they pass parameters, especially numbers, as numeric types rather than strings. This raises an error in GDAL eventually, but the error message gives no indication about where the problem actually lies. This validates the parameters are strings before handing them off to GDAL, and will raise an error if they are not.

## Notes
This also adds a PR template and CHANGELOG in preparation for a 1.0.0 release.

## Testing Instructions                                                         
                                                                                
 * Run tests, they should pass.
                          
## Checklist                                                                    
                                                                                
- [X] Add entry to CHANGELOG.md                                                 
                                                                                
Resolves #19 