### PR TITLE
Make dataset operations atomic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 ## Upcoming release
+- Remove closeAndReadBytes(), flushFS(), and convert close() to a no-op.
 - Set up CI and automatic releases via GitHub Actions
 - Package updates to resolve security alerts
 - Validate that parameters to `warp()` and `convert()` are strings

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 ## Upcoming release
+- Add loam.rasterize() wrapper for GDALRasterize()
+- Add pathPrefix parameter to loam.initialize()
 - Remove closeAndReadBytes(), flushFS(), and convert close() to a no-op.
 - Set up CI and automatic releases via GitHub Actions
 - Package updates to resolve security alerts

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ A promise which resolves to the affine transform.
 ### `GDALDataset.convert(args)`
 Converts raster data between different formats. This is the equivalent of the [gdal_translate](https://gdal.org/programs/gdal_translate.html) command.
 
-**Note**: This returns a new `GDALDataset` object but does not perform any immediate calculation. Instead, calls to `.convert()` and `.warp()` are evaluated lazily. Each successive call to `.convert()` or `.warp()` is stored in a list of operations on the dataset oboject. These operations are only evaluated when necessary in order to access some property of the dataset, such as its size, bytes, or band count.
+**Note**: This returns a new `GDALDataset` object but does not perform any immediate calculation. Instead, calls to `.convert()` and `.warp()` are evaluated lazily. Each successive call to `.convert()` or `.warp()` is stored in a list of operations on the dataset object. These operations are only evaluated when necessary in order to access some property of the dataset, such as its size, bytes, or band count.
 #### Parameters
 - `args`: An array of strings, each representing a single command-line argument accepted by the `gdal_translate` command. The `src_dataset` and `dst_dataset` parameters should be omitted; these are handled by `GDALDataset`. Example: `ds.convert(['-outsize', '200%', '200%'])`
 #### Return value
@@ -116,7 +116,7 @@ A promise that resolves to a new `GDALDataset`.
 ### `GDALDataset.warp(args)`
 Image reprojection and warping utility. This is the equivalent of the [gdalwarp](https://gdal.org/programs/gdalwarp.html) command.
 
-**Note**: This returns a new `GDALDataset` object but does not perform any immediate calculation. Instead, calls to `.convert()` and `.warp()` are evaluated lazily. Each successive call to `.convert()` or `.warp()` is stored in a list of operations on the dataset oboject. These operations are only evaluated when necessary in order to access some property of the dataset, such as its size, bytes, or band count.
+**Note**: This returns a new `GDALDataset` object but does not perform any immediate calculation. Instead, calls to `.convert()` and `.warp()` are evaluated lazily. Each successive call to `.convert()` or `.warp()` is stored in a list of operations on the dataset object. These operations are only evaluated when necessary in order to access some property of the dataset, such as its size, bytes, or band count.
 #### Parameters
 - `args`: An array of strings, each representing a single [command-line argument](https://gdal.org/programs/gdalwarp.html#synopsis) accepted by the `gdalwarp` command. The `srcfile` and `dstfile` parameters should be omitted; these are handled by `GDALDataset`. Example: `ds.warp(['-s_srs', 'EPSG:3857', '-t_srs', 'EPSG:4326'])`
 #### Return value

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ loam.initialize();
 // Assuming you have a `Blob` object from somewhere. `File` objects also work.
 loam.open(blob).then((dataset) => {
   dataset.width()
-    .then((width) => /* do stuff with width */)
-    .then(() => dataset.close()); // It's important to close datasets after you're done with them
+    .then((width) => /* do stuff with width */);
 ```
 
 ## Functions
@@ -62,16 +61,9 @@ A promise that resolves with an array of transformed coordinate pairs.
 <br />
 
 ### `GDALDataset.close()`
-Closes the dataset and cleans up its associated resources. Currently, Loam is subject to memory leaks if this function is not called to clean up unused GDALDatasets. A future goal is to eliminate the need for this.
+This used to be required in order to avoid memory leaks in earlier versions of Loam, but is currently a no-op. It has been maintained to preserve backwards compatibility, but has no effect other than to display a console warning.
 #### Return value
-A promise that resolves when the dataset has been closed and cleaned up.
-
-<br />
-
-### `GDALDataset.closeAndReadBytes()`
-Behaves the same as `GDALDataset.close()`, except that the promise returned is resolved with the contents of the dataset, as a byte array.
-#### Return value
-A promise that resolves when the dataset has been closed. The promise contains the dataset contents as a byte array.
+A promise that resolves immediately with an empty list (for historical reasons).
 
 <br />
 
@@ -113,22 +105,22 @@ A promise which resolves to the affine transform.
 ### `GDALDataset.convert(args)`
 Converts raster data between different formats. This is the equivalent of the [gdal_translate](https://gdal.org/programs/gdal_translate.html) command.
 
-**Note**: This returns a new `GDALDataset` object. It is necessary to call `.close()` on both the original dataset _and_ the new dataset in order to avoid memory leaks.
+**Note**: This returns a new `GDALDataset` object but does not perform any immediate calculation. Instead, calls to `.convert()` and `.warp()` are evaluated lazily. Each successive call to `.convert()` or `.warp()` is stored in a list of operations on the dataset oboject. These operations are only evaluated when necessary in order to access some property of the dataset, such as its size, bytes, or band count.
 #### Parameters
 - `args`: An array of strings, each representing a single command-line argument accepted by the `gdal_translate` command. The `src_dataset` and `dst_dataset` parameters should be omitted; these are handled by `GDALDataset`. Example: `ds.convert(['-outsize', '200%', '200%'])`
 #### Return value
-A promise that resolves to a new `GDALDataset` which has been converted according to the provided arguments to `gdal_translate`.
+A promise that resolves to a new `GDALDataset`.
 
 <br />
 
 ### `GDALDataset.warp(args)`
 Image reprojection and warping utility. This is the equivalent of the [gdalwarp](https://gdal.org/programs/gdalwarp.html) command.
 
-**Note**: This returns a new `GDALDataset` object. It is necessary to call `.close()` on both the original dataset _and_ the new dataset in order to avoid memory leaks.
+**Note**: This returns a new `GDALDataset` object but does not perform any immediate calculation. Instead, calls to `.convert()` and `.warp()` are evaluated lazily. Each successive call to `.convert()` or `.warp()` is stored in a list of operations on the dataset oboject. These operations are only evaluated when necessary in order to access some property of the dataset, such as its size, bytes, or band count.
 #### Parameters
 - `args`: An array of strings, each representing a single [command-line argument](https://gdal.org/programs/gdalwarp.html#synopsis) accepted by the `gdalwarp` command. The `srcfile` and `dstfile` parameters should be omitted; these are handled by `GDALDataset`. Example: `ds.warp(['-s_srs', 'EPSG:3857', '-t_srs', 'EPSG:4326'])`
 #### Return value
-A promise that resolves to a new `GDALDataset` which has been reprojected according to the provided arguments to `gdalwarp`.
+A promise that resolves to a new `GDALDataset`.
 
 # Developing
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "yargs": "^14.0.0"
   },
   "dependencies": {
-    "gdal-js": "^1.1.0"
+    "gdal-js": "2.0.0"
   }
 }

--- a/src/api.js
+++ b/src/api.js
@@ -3,9 +3,15 @@ import { GDALDataset } from './gdalDataset.js';
 
 function open(file) {
     return new Promise((resolve, reject) => {
-        const ds = new GDALDataset(file);
+        const ds = new GDALDataset({func: 'GDALOpen', src: file, args: []});
 
         return ds.open().then(() => resolve(ds), (reason) => reject(reason));
+    });
+}
+
+function rasterize(geojson, args) {
+    return new Promise((resolve, reject) => {
+        resolve(new GDALDataset({func: 'GDALRasterize', src: geojson, args: args}));
     });
 }
 
@@ -16,8 +22,8 @@ function reproject(fromCRS, toCRS, coords) {
     return runOnWorker('LoamReproject', [fromCRS, toCRS, xCoords, yCoords]);
 }
 
-function initialize() {
-    return initWorker();
+function initialize(pathPrefix) {
+    return initWorker(pathPrefix);
 }
 
-export { open, initialize, reproject };
+export { open, rasterize, initialize, reproject };

--- a/src/api.js
+++ b/src/api.js
@@ -1,33 +1,23 @@
-import { initWorker, callWorker } from './workerCommunication.js';
-import GDALDataset from './gdalDataset.js';
+import { initWorker, runOnWorker } from './workerCommunication.js';
+import { GDALDataset } from './gdalDataset.js';
 
 function open(file) {
-    return callWorker('GDALOpen', [file]).then(
-        function (openResult) {
-            return new GDALDataset(
-                openResult.datasetPtr,
-                openResult.filePath,
-                openResult.directory,
-                openResult.filename
-            );
-        },
-        function (error) { throw error; }
-    );
+    return new Promise((resolve, reject) => {
+        const ds = new GDALDataset(file);
+
+        return ds.open().then(() => resolve(ds), (reason) => reject(reason));
+    });
 }
 
 function reproject(fromCRS, toCRS, coords) {
     var xCoords = new Float64Array(coords.map(function (pair) { return pair[0]; }));
     var yCoords = new Float64Array(coords.map(function (pair) { return pair[1]; }));
 
-    return callWorker('LoamReproject', [fromCRS, toCRS, xCoords, yCoords]);
-}
-
-function flushFS() {
-    return callWorker('LoamFlushFS', []);
+    return runOnWorker('LoamReproject', [fromCRS, toCRS, xCoords, yCoords]);
 }
 
 function initialize() {
     return initWorker();
 }
 
-export { open, flushFS, initialize, reproject };
+export { open, initialize, reproject };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 import { open, flushFS, initialize, reproject } from './api.js';
-import GDALDataset from './gdalDataset.js';
+import { GDALDataset } from './gdalDataset.js';
 
 export default { open, flushFS, GDALDataset, initialize, reproject };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { open, flushFS, initialize, reproject } from './api.js';
+import { open, rasterize, initialize, reproject } from './api.js';
 import { GDALDataset } from './gdalDataset.js';
 
-export default { open, flushFS, GDALDataset, initialize, reproject };
+export default { open, rasterize, GDALDataset, initialize, reproject };

--- a/src/worker.js
+++ b/src/worker.js
@@ -4,6 +4,7 @@
 // The wrappers are factories that return functions which perform the necessary setup and
 // teardown for interacting with GDAL inside Emscripten world.
 import wGDALOpen from './wrappers/gdalOpen.js';
+import wGDALRasterize from './wrappers/gdalRasterize.js';
 import wGDALClose from './wrappers/gdalClose.js';
 import wGDALGetRasterCount from './wrappers/gdalGetRasterCount.js';
 import wGDALGetRasterXSize from './wrappers/gdalGetRasterXSize.js';
@@ -70,6 +71,17 @@ self.Module = {
             //
             registry.GDALOpen = wGDALOpen(
                 self.Module.cwrap('GDALOpen', 'number', ['string']),
+                errorHandling,
+                DATASETPATH
+            );
+            registry.GDALRasterize = wGDALRasterize(
+                self.Module.cwrap('GDALRasterize', 'number', [
+                    'string', // Destination dataset path or NULL
+                    'number', // GDALDatasetH destination dataset or NULL
+                    'number', // GDALDatasetH source dataset or NULL
+                    'number', // GDALRasterizeOptions * or NULL
+                    'number' // int * to use for error reporting
+                ]),
                 errorHandling,
                 DATASETPATH
             );
@@ -146,7 +158,7 @@ importScripts('gdal.js');
 
 function handleDatasetAccess(accessor, dataset) {
     // 1: Open the source.
-    let srcDs = registry.GDALOpen(dataset.source);
+    let srcDs = registry[dataset.source.func](dataset.source.src, dataset.source.args);
 
     let resultDs = srcDs;
 

--- a/src/workerCommunication.js
+++ b/src/workerCommunication.js
@@ -18,10 +18,12 @@ function getPathPrefix() {
 }
 
 // Set up a WebWorker and an associated promise that resolves once it's ready
-function initWorker() {
+function initWorker(pathPrefix) {
+    pathPrefix = pathPrefix || getPathPrefix();
+
     if (typeof workerPromise === 'undefined') {
         workerPromise = new Promise(function (resolve, reject) {
-            let _worker = new Worker(getPathPrefix() + 'loam-worker.js');
+            let _worker = new Worker(pathPrefix + 'loam-worker.js');
 
             // The worker needs to do some initialization, and will send a message when it's ready.
             _worker.onmessage = function (msg) {

--- a/src/wrappers/gdalClose.js
+++ b/src/wrappers/gdalClose.js
@@ -7,6 +7,7 @@ export default function (GDALClose, errorHandling) {
         if (returnFileBytes) {
             result = FS.readFile(datasetPath, { encoding: 'binary' });
         }
+
         FS.unmount(directory);
         FS.rmdir(directory);
 

--- a/src/wrappers/gdalOpen.js
+++ b/src/wrappers/gdalOpen.js
@@ -5,7 +5,7 @@ export default function (GDALOpen, errorHandling, rootPath) {
     return function (file) {
         let filename;
 
-        let directory = rootPath + '/' + randomKey();
+        let directory = rootPath + randomKey();
 
         FS.mkdir(directory);
 

--- a/src/wrappers/gdalRasterize.js
+++ b/src/wrappers/gdalRasterize.js
@@ -1,0 +1,132 @@
+/* global Module, FS, MEMFS */
+import randomKey from '../randomKey.js';
+import guessFileExtension from '../guessFileExtension.js';
+import { isArrayAllStrings } from '../validation.js';
+
+export default function (GDALRasterize, errorHandling, rootPath) {
+    return function (geojson, args) {
+        if (!isArrayAllStrings(args)) {
+            throw new Error('All items in the argument list must be strings');
+        }
+        // Make a temporary file location to hold the geojson
+        const geojsonPath = rootPath + randomKey() + '.geojson';
+
+        FS.writeFile(geojsonPath, JSON.stringify(geojson));
+        // Append the geojson path to the args so that it's read as the source.
+        // Open the geojson using GDALOpenEx, which can handle non-raster sources.
+        const datasetPtr = Module.ccall('GDALOpenEx', 'number', ['string'], [geojsonPath]);
+
+        // TODO: Break this out into a util function; this pattern is showing up in several places now.
+        // So first, we need to allocate Emscripten heap space sufficient to store each string as a
+        // null-terminated C string.
+        // Because the C function signature is char **, this array of pointers is going to need to
+        // get copied into Emscripten heap space eventually, so we're going to prepare by storing
+        // the pointers as a typed array so that we can more easily copy it into heap space later.
+        const argPtrsArray = Uint32Array.from(args.map(argStr => {
+            return Module._malloc(Module.lengthBytesUTF8(argStr) + 1); // +1 for the null terminator byte
+        }).concat([0]));
+        // ^ In addition to each individual argument being null-terminated, the GDAL docs specify that
+        // GDALRasterizeOptionsNew takes its options passed in as a null-terminated array of
+        // pointers, so we have to add on a null (0) byte at the end.
+
+        // Next, we need to write each string from the JS string array into the Emscripten heap space
+        // we've allocated for it.
+        args.forEach(function (argStr, i) {
+            Module.stringToUTF8(argStr, argPtrsArray[i], Module.lengthBytesUTF8(argStr) + 1);
+        });
+
+        // Now, as mentioned above, we also need to copy the pointer array itself into heap space.
+        let argPtrsArrayPtr = Module._malloc(argPtrsArray.length * argPtrsArray.BYTES_PER_ELEMENT);
+
+        Module.HEAPU32.set(argPtrsArray, argPtrsArrayPtr / argPtrsArray.BYTES_PER_ELEMENT);
+
+        // Whew, all finished. argPtrsArrayPtr is now the address of the start of the list of
+        // pointers in Emscripten heap space. Each pointer identifies the address of the start of a
+        // parameter string, also stored in heap space. This is the direct equivalent of a char **,
+        // which is what GDALRasterizeOptionsNew requires.
+
+        let rasterizeOptionsPtr = Module.ccall('GDALRasterizeOptionsNew', 'number',
+            ['number', 'number'],
+            [argPtrsArrayPtr, null]
+        );
+
+        // Validate that the options were correct
+        let optionsErrType = errorHandling.CPLGetLastErrorType();
+
+        if (optionsErrType === errorHandling.CPLErr.CEFailure ||
+          optionsErrType === errorHandling.CPLErr.CEFatal) {
+            Module.ccall('GDALClose', 'number', ['number'], datasetPtr);
+            FS.unlink(geojsonPath);
+            Module._free(argPtrsArrayPtr);
+            // Don't try to free the null terminator byte
+            argPtrsArray.subarray(0, argPtrsArray.length - 1).forEach(ptr => Module._free(ptr));
+            const message = errorHandling.CPLGetLastErrorMsg();
+
+            throw new Error(message);
+        }
+
+        // Now that we have our translate options, we need to make a file location to hold the output.
+        let directory = rootPath + '/' + randomKey();
+
+        FS.mkdir(directory);
+        // This makes it easier to remove later because we can just unmount rather than recursing
+        // through the whole directory structure.
+        FS.mount(MEMFS, {}, directory);
+        let filename = randomKey(8) + '.' + guessFileExtension(args);
+
+        let filePath = directory + '/' + filename;
+
+        // And then we can kick off the actual warping process.
+        // TODO: The last parameter is an int* that can be used to detect certain kinds of errors,
+        // but I'm not sure how it works yet and whether it gives the same or different information
+        // than CPLGetLastErrorType
+        // We can get some error information out of the final pbUsageError parameter, which is an
+        // int*, so malloc ourselves an int and set it to 0 (False)
+        let usageErrPtr = Module._malloc(Int32Array.BYTES_PER_ELEMENT);
+
+        Module.setValue(usageErrPtr, 0, 'i32');
+
+        let newDatasetPtr = GDALRasterize(
+            filePath, // Output
+            0, // NULL because filePath is not NULL
+            datasetPtr,
+            rasterizeOptionsPtr,
+            usageErrPtr
+        );
+
+        let errorType = errorHandling.CPLGetLastErrorType();
+        // If we ever want to use the usage error pointer:
+        // let usageErr = Module.getValue(usageErrPtr, 'i32');
+
+        // The final set of cleanup we need to do, in a function to avoid writing it twice.
+        function cleanUp() {
+            Module.ccall('GDALClose', 'number', ['number'], datasetPtr);
+            FS.unlink(geojsonPath);
+            Module.ccall('GDALRasterizeOptionsFree', null, ['number'], [rasterizeOptionsPtr]);
+            Module._free(argPtrsArrayPtr);
+            Module._free(usageErrPtr);
+            // Don't try to free the null terminator byte
+            argPtrsArray.subarray(0, argPtrsArray.length - 1).forEach(ptr => Module._free(ptr));
+        }
+
+        // Check for errors; clean up and throw if error is detected
+        if (errorType === errorHandling.CPLErr.CEFailure ||
+                errorType === errorHandling.CPLErr.CEFatal) {
+            cleanUp();
+            const message = errorHandling.CPLGetLastErrorMsg();
+
+            throw new Error(message);
+        } else {
+            const result = {
+                datasetPtr: newDatasetPtr,
+                filePath: filePath,
+                directory: directory,
+                filename: filename
+            };
+
+            cleanUp();
+
+            return result;
+        }
+    };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2387,10 +2387,10 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-gdal-js@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/gdal-js/-/gdal-js-1.1.3.tgz#2f5e80078e06722e38e051f1b3eba3e73c9b6d24"
-  integrity sha512-5Twt9mUzHcBONHxsMzWKfYVO2MfxBpJeiZ+llVqhBZ591dq7bu8i4GVEDKW9wlni9dSCQOKrkZn+ekINP+0mYg==
+gdal-js@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gdal-js/-/gdal-js-2.0.0.tgz#8b30fc0ca5932e9eb185f9678d2ad9091b29d77b"
+  integrity sha512-7FzClImugPJsu/kIV884JN++cwnbh9oIE9p1tJuNDyCJS++i3IiL4uJaOYKKr3rqPOv7ECeHCfwW7r50rF04yg==
 
 get-caller-file@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
## Overview

Specifically, this no longer makes permanent changes to the Emscripten
emulated "file system" inside each web worker, which removes the need to
call "close()" on each individual dataset, and the risk of memory leaks
if someone forgets to do this.

Instead, operations that would result in a new dataset, which at this
point includes ~only GDALWarp and GDALTranslate~ GDALWarp,
GDALTranslate, and GDALRasterize, are stored in an array with their
arguments on the main thread. A Loam Dataset is now a source
plus a list of operations, rather than a pointer to an open GDALDatasetH
inside the web worker's memory.

Besides removing the risk of memory leaks, this also improves
performance when multiple transformations are requested consecutively.

To see why, consider a "tiler" style application, which first uses
GDALWarp to select windows of a GeoTIFF and then GDALTranslate to
convert them to PNGs.

Because tiles are requested faster than they can be processed, under the
old model, the worker will receive the GDALWarp commands first, which
will result in it generating a large number of new datasets, one for
each tile. These datasets will remain in the Worker's memory until they
are closed, which can put memory pressure on the application and slow
down later stages. Next, under the old model, each warped tile will be
converted to a PNG and returned to the main thread, and finally, each
dataset will be closed.

Visually, the practical effect of this is that the user will see a blank
map for some time, and then suddenly all the tiles will fill in all at
once.

Under the new model, each tile is warped, converted to a PNG, and closed
all in one step before processing the next tile, so tiles appear
immediately as they are processed.

One area where this could hurt performance is if a dataset has a long,
complex chain of operations applied to it and then the user wants to
access multiple properties of the resulting dataset. Currently, this
will need to re-calculate the entire dataset each time, which will make
each individual property access slow. The best workaround at this point
for this situation is to call bytes() as a final step and then create a
new dataset from the resulting Blob. However, it would also be feasible
to allow the user to pass in a request for multiple properties to be
satisfied at once, which might be a helpful future enhancement.

## Notes
- This is not an urgent PR, there is no rush to review it.
- There is one notable breaking API change here, which is that `.closeAndReadBytes()` has been removed in favor of a `.bytes()` method on the dataset. This is an easy change to make and I'm intending to release these changes as part of the 1.0.0 release (the library is currently marked `alpha`), so I just went ahead and removed it, but if backwards compatibility is a concern, I'm happy to add it back with a warning to use `.bytes()` in the future.
- There's one other breaking change, which is the removal of `flushFS()`, but that was primarily written for testing purposes so I think it's fine to just remove it.
- @alkamin I'm planning to take over and finish off #26 as my next task unless you'd still like to work on it--let me know if that's okay.

## Testing Instructions

 * Ensure that CI passes
 * If you want to get major bonus points, you could build the library, and upgrade it in a place where we use Loam in a project (Warpr or RF) to confirm that it still works.

## Checklist

- [x] Add entry to CHANGELOG.md
- [x] Update the README with any function signature changes

Resolves #21 
