### PR TITLE
Add GDALRasterize

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 ## Upcoming release
 - Add loam.rasterize() wrapper for GDALRasterize()
+- Add pathPrefix parameter to loam.initialize()
 - Remove closeAndReadBytes(), flushFS(), and convert close() to a no-op.
 - Set up CI and automatic releases via GitHub Actions
 - Package updates to resolve security alerts

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 ## Upcoming release
+- Add loam.rasterize() wrapper for GDALRasterize()
 - Remove closeAndReadBytes(), flushFS(), and convert close() to a no-op.
 - Set up CI and automatic releases via GitHub Actions
 - Package updates to resolve security alerts

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ A promise that resolves with an instance of `GDALDataset`.
 
 <br />
 
+### `loam.rasterize(geojson, args)`
+Burns vectors in GeoJSON format into rasters. This is the equivalent of the [gdal_rasterize](https://gdal.org/programs/gdal_rasterize.html) command.
+
+**Note**: This returns a new `GDALDataset` object but does not perform any immediate calculation. Instead, calls to `.rasterize()` are evaluated lazily (as with `convert()` and `warp()`, below). The rasterization operation is only evaluated when necessary in order to access some property of the dataset, such as its size, bytes, or band count. Successive calls to `.warp()` and `.convert()` can be lazily chained onto datasets produced via `loam.rasterize()`.
+#### Parameters
+- `geojson`: A Javascript object (_not_ a string) in [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) format. 
+- `args`: An array of strings, each representing a single command-line argument accepted by the `gdal_rasterize` command. The `src_datasource` and `dst_filename` parameters should be omitted; these are handled internally by Loam. Example (assuming you have a properly structured GeoJSON object): `loam.rasterize(geojson, ['-burn', '1.0', '-of', 'GTiff', '-ts', '200', '200'])`
+#### Return value
+A promise that resolves to a new `GDALDataset`.
+
+<br />
+
 ### `loam.reproject(fromCRS, toCRS, coords)`
 Reproject coordinates from one coordinate system to another using PROJ.4.
 #### Parameters

--- a/README.md
+++ b/README.md
@@ -31,12 +31,16 @@ loam.open(blob).then((dataset) => {
 ```
 
 ## Functions
-### `loam.initialize()`
+### `loam.initialize(pathPrefix)`
 Manually set up web worker and initialize Emscripten runtime. This function is called automatically by other functions on `loam`. Returns a promise that is resolved when Loam is fully initialized.
 
 Although this function is called automatically by other functions, such as `loam.open()`, it is often beneficial for user experience to manually call `loam.initialize()`, because it allows pre-fetching Loam's WebAssembly assets (which are several megabytes uncompressed) at a time when the latency required to download them will be least perceptible by the user. For example, `loam.initialize()` could be called when the user clicks a button to open a file-selection dialog, allowing the WebAssembly to load in the background while the user selects a file.
 
 This function is safe to call multiple times.
+#### Parameters
+- `pathPrefix`: The path prefix that Loam should use when downloading its WebAssembly assets. If left undefined, Loam will make a best guess based on the source path of its own `<script>` element. If Loam fails to work properly and you see requests resulting in 404s for the `gdal.*` assets listed above, then you will need to set this parameter so that Loam requests the correct paths for its WebAssembly assets.
+#### Return value
+A promise that resolves when Loam is initialized. All of the functions described in this document wait for this promise's resolution when executing, so paying attention to whether this promise has resolved or not is not required. However, it may be helpful to do so in some circumstances, for example, if you want to display a visual indicator that your app is ready.
 
 <br />
 

--- a/src/api.js
+++ b/src/api.js
@@ -16,8 +16,8 @@ function reproject(fromCRS, toCRS, coords) {
     return runOnWorker('LoamReproject', [fromCRS, toCRS, xCoords, yCoords]);
 }
 
-function initialize() {
-    return initWorker();
+function initialize(pathPrefix) {
+    return initWorker(pathPrefix);
 }
 
 export { open, initialize, reproject };

--- a/src/api.js
+++ b/src/api.js
@@ -3,9 +3,15 @@ import { GDALDataset } from './gdalDataset.js';
 
 function open(file) {
     return new Promise((resolve, reject) => {
-        const ds = new GDALDataset(file);
+        const ds = new GDALDataset({func: 'GDALOpen', src: file, args: []});
 
         return ds.open().then(() => resolve(ds), (reason) => reject(reason));
+    });
+}
+
+function rasterize(geojson, args) {
+    return new Promise((resolve, reject) => {
+        resolve(new GDALDataset({func: 'GDALRasterize', src: geojson, args: args}));
     });
 }
 
@@ -20,4 +26,4 @@ function initialize(pathPrefix) {
     return initWorker(pathPrefix);
 }
 
-export { open, initialize, reproject };
+export { open, rasterize, initialize, reproject };

--- a/src/gdalDataset.js
+++ b/src/gdalDataset.js
@@ -68,4 +68,18 @@ export class GDALDataset {
             resolve([]);
         });
     }
+
+    rasterize(args) {
+        return callWorker('GDALRasterize', [this.datasetPtr, args]).then(
+            function (result) {
+                return new GDALDataset(
+                    result.datasetPtr,
+                    result.filePath,
+                    result.directory,
+                    result.filename
+                );
+            },
+            function (error) { throw error; }
+        );
+    }
 }

--- a/src/gdalDataset.js
+++ b/src/gdalDataset.js
@@ -68,18 +68,4 @@ export class GDALDataset {
             resolve([]);
         });
     }
-
-    rasterize(args) {
-        return callWorker('GDALRasterize', [this.datasetPtr, args]).then(
-            function (result) {
-                return new GDALDataset(
-                    result.datasetPtr,
-                    result.filePath,
-                    result.directory,
-                    result.filename
-                );
-            },
-            function (error) { throw error; }
-        );
-    }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { open, flushFS, initialize, reproject } from './api.js';
+import { open, rasterize, initialize, reproject } from './api.js';
 import { GDALDataset } from './gdalDataset.js';
 
-export default { open, flushFS, GDALDataset, initialize, reproject };
+export default { open, rasterize, GDALDataset, initialize, reproject };

--- a/src/worker.js
+++ b/src/worker.js
@@ -4,6 +4,7 @@
 // The wrappers are factories that return functions which perform the necessary setup and
 // teardown for interacting with GDAL inside Emscripten world.
 import wGDALOpen from './wrappers/gdalOpen.js';
+import wGDALRasterize from './wrappers/gdalRasterize.js';
 import wGDALClose from './wrappers/gdalClose.js';
 import wGDALGetRasterCount from './wrappers/gdalGetRasterCount.js';
 import wGDALGetRasterXSize from './wrappers/gdalGetRasterXSize.js';
@@ -70,6 +71,17 @@ self.Module = {
             //
             registry.GDALOpen = wGDALOpen(
                 self.Module.cwrap('GDALOpen', 'number', ['string']),
+                errorHandling,
+                DATASETPATH
+            );
+            registry.GDALRasterize = wGDALRasterize(
+                self.Module.cwrap('GDALRasterize', 'number', [
+                    'string', // Destination dataset path or NULL
+                    'number', // GDALDatasetH destination dataset or NULL
+                    'number', // GDALDatasetH source dataset or NULL
+                    'number', // GDALRasterizeOptions * or NULL
+                    'number' // int * to use for error reporting
+                ]),
                 errorHandling,
                 DATASETPATH
             );
@@ -146,7 +158,7 @@ importScripts('gdal.js');
 
 function handleDatasetAccess(accessor, dataset) {
     // 1: Open the source.
-    let srcDs = registry.GDALOpen(dataset.source);
+    let srcDs = registry[dataset.source.func](dataset.source.src, dataset.source.args);
 
     let resultDs = srcDs;
 

--- a/src/workerCommunication.js
+++ b/src/workerCommunication.js
@@ -18,10 +18,12 @@ function getPathPrefix() {
 }
 
 // Set up a WebWorker and an associated promise that resolves once it's ready
-function initWorker() {
+function initWorker(pathPrefix) {
+    pathPrefix = pathPrefix || getPathPrefix();
+
     if (typeof workerPromise === 'undefined') {
         workerPromise = new Promise(function (resolve, reject) {
-            let _worker = new Worker(getPathPrefix() + 'loam-worker.js');
+            let _worker = new Worker(pathPrefix + 'loam-worker.js');
 
             // The worker needs to do some initialization, and will send a message when it's ready.
             _worker.onmessage = function (msg) {

--- a/src/wrappers/gdalRasterize.js
+++ b/src/wrappers/gdalRasterize.js
@@ -1,0 +1,114 @@
+/* global Module, FS, MEMFS */
+import randomKey from '../randomKey.js';
+import guessFileExtension from '../guessFileExtension.js';
+
+export default function (GDALRasterize, errorHandling, rootPath) {
+    return function (datasetPtr, args) {
+        // So first, we need to allocate Emscripten heap space sufficient to store each string as a
+        // null-terminated C string.
+        // Because the C function signature is char **, this array of pointers is going to need to
+        // get copied into Emscripten heap space eventually, so we're going to prepare by storing
+        // the pointers as a typed array so that we can more easily copy it into heap space later.
+        let argPtrsArray = Uint32Array.from(args.map(argStr => {
+            return Module._malloc(Module.lengthBytesUTF8(argStr) + 1); // +1 for the null terminator byte
+        }).concat([0]));
+        // ^ In addition to each individual argument being null-terminated, the GDAL docs specify that
+        // GDALRasterizeOptionsNew takes its options passed in as a null-terminated array of
+        // pointers, so we have to add on a null (0) byte at the end.
+
+        // Next, we need to write each string from the JS string array into the Emscripten heap space
+        // we've allocated for it.
+        args.forEach(function (argStr, i) {
+            Module.stringToUTF8(argStr, argPtrsArray[i], Module.lengthBytesUTF8(argStr) + 1);
+        });
+
+        // Now, as mentioned above, we also need to copy the pointer array itself into heap space.
+        let argPtrsArrayPtr = Module._malloc(argPtrsArray.length * argPtrsArray.BYTES_PER_ELEMENT);
+
+        Module.HEAPU32.set(argPtrsArray, argPtrsArrayPtr / argPtrsArray.BYTES_PER_ELEMENT);
+
+        // Whew, all finished. argPtrsArrayPtr is now the address of the start of the list of
+        // pointers in Emscripten heap space. Each pointer identifies the address of the start of a
+        // parameter string, also stored in heap space. This is the direct equivalent of a char **,
+        // which is what GDALRasterizeOptionsNew requires.
+
+        let rasterizeOptionsPtr = Module.ccall('GDALRasterizeOptionsNew', 'number',
+            ['number', 'number'],
+            [argPtrsArrayPtr, null]
+        );
+
+        // Validate that the options were correct
+        let optionsErrType = errorHandling.CPLGetLastErrorType();
+
+        if (optionsErrType === errorHandling.CPLErr.CEFailure ||
+          optionsErrType === errorHandling.CPLErr.CEFatal) {
+            Module._free(argPtrsArrayPtr);
+            // Don't try to free the null terminator byte
+            argPtrsArray.subarray(0, argPtrsArray.length - 1).forEach(ptr => Module._free(ptr));
+            const message = errorHandling.CPLGetLastErrorMsg();
+
+            throw new Error(message);
+        }
+
+        // Now that we have our translate options, we need to make a file location to hold the output.
+        let directory = rootPath + '/' + randomKey();
+
+        FS.mkdir(directory);
+        // This makes it easier to remove later because we can just unmount rather than recursing
+        // through the whole directory structure.
+        FS.mount(MEMFS, {}, directory);
+        let filename = randomKey(8) + '.' + guessFileExtension(args);
+        let filePath = directory + '/' + filename;
+
+        // And then we can kick off the actual warping process.
+        // TODO: The last parameter is an int* that can be used to detect certain kinds of errors,
+        // but I'm not sure how it works yet and whether it gives the same or different information
+        // than CPLGetLastErrorType
+        // We can get some error information out of the final pbUsageError parameter, which is an
+        // int*, so malloc ourselves an int and set it to 0 (False)
+        let usageErrPtr = Module._malloc(Int32Array.BYTES_PER_ELEMENT);
+
+        Module.setValue(usageErrPtr, 0, 'i32');
+
+        let newDatasetPtr = GDALRasterize(
+            filePath, // Output
+            0, // NULL because filePath is not NULL
+            datasetPtr,
+            rasterizeOptionsPtr,
+            usageErrPtr
+        );
+
+        let errorType = errorHandling.CPLGetLastErrorType();
+        // If we ever want to use the usage error pointer:
+        // let usageErr = Module.getValue(usageErrPtr, 'i32');
+
+        // The final set of cleanup we need to do, in a function to avoid writing it twice.
+        function cleanUp() {
+            Module.ccall('GDALRasterizeOptionsFree', null, ['number'], [rasterizeOptionsPtr]);
+            Module._free(argPtrsArrayPtr);
+            Module._free(usageErrPtr);
+            // Don't try to free the null terminator byte
+            argPtrsArray.subarray(0, argPtrsArray.length - 1).forEach(ptr => Module._free(ptr));
+        }
+
+        // Check for errors; clean up and throw if error is detected
+        if (errorType === errorHandling.CPLErr.CEFailure ||
+                errorType === errorHandling.CPLErr.CEFatal) {
+            cleanUp();
+            const message = errorHandling.CPLGetLastErrorMsg();
+
+            throw new Error(message);
+        } else {
+            const result = {
+                datasetPtr: newDatasetPtr,
+                filePath: filePath,
+                directory: directory,
+                filename: filename
+            };
+
+            cleanUp();
+
+            return result;
+        }
+    };
+}

--- a/test/loam.spec.js
+++ b/test/loam.spec.js
@@ -1,8 +1,9 @@
-/* global describe, it, before, afterEach, expect, loam */
+/* global describe, it, before, expect, loam */
 const tinyTifPath = '/base/test/assets/tiny.tif';
 const invalidTifPath = 'base/test/assets/not-a-tiff.bytes';
 const epsg4326 = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]';
 const epsg3857 = 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"],AUTHORITY["EPSG","3857"]]';
+const geojson = {type: 'FeatureCollection', features: [{type: 'Feature', properties: {}, geometry: {type: 'Polygon', coordinates: [[[-75.15416622161865, 39.96212240336062], [-75.15519618988037, 39.96115204441345], [-75.15409111976624, 39.96055173071228], [-75.15339374542236, 39.96149742799007], [-75.15416622161865, 39.96212240336062]]]}}]}
 
 function xhrAsPromiseBlob(url) {
     let xhr = new XMLHttpRequest();
@@ -172,9 +173,33 @@ describe('Given that loam exists', () => {
         });
     });
 
+    describe('calling rasterize', function () {
+        it('should succeed and return a rasterized version of the GeoJSON', function () {
+            return loam.rasterize(geojson, ['-burn', '1', '-of', 'GTiff', '-ts', '10', '10'])
+                .then(ds => ds.bytes())
+                // Byte length was experimentally determined by running gdal_rasterize from the
+                // command-line
+                .then(bytes => expect(bytes.length).to.equal(1166));
+        });
+    });
+
     /**
      * Failure cases
      **/
+    describe('calling open() on an invalid file', function () {
+        it('should fail and return an error message', function () {
+            return xhrAsPromiseBlob(invalidTifPath)
+                .then(garbage => loam.open(garbage))
+                .then(
+                    () => {
+                        throw new Error('GDALOpen promise should have been rejected');
+                    },
+                    error => expect(error.message).to.include(
+                        'not recognized as a supported file format'
+                    )
+                );
+        });
+    });
 
     describe('calling convert with invalid arguments', function () {
         it('should fail and return an error message', function () {
@@ -216,6 +241,25 @@ describe('Given that loam exists', () => {
         });
     });
 
+    describe('calling rasterize with invalid arguments', function () {
+        it('should fail and return an error message', function () {
+            // The -ts parameter is for output image size, so negative values are nonsensical
+            return loam.rasterize(geojson, ['-burn', '1', '-of', 'GTiff', '-ts', '-10', '10'])
+                .then(ds => ds.bytes()) // Need to call an accessor to trigger operation execution
+                .then(
+                    (result) => {
+                        throw new Error(
+                            'rasterize() promise should have been rejected but got ' +
+                            result + ' instead.'
+                        );
+                    },
+                    error => expect(error.message).to.include(
+                        'Wrong value for -outsize parameter.'
+                    )
+                );
+        });
+    });
+
     describe('calling convert with non-string arguments', function () {
         it('should fail and return an error message', function () {
             return xhrAsPromiseBlob(tinyTifPath)
@@ -246,6 +290,24 @@ describe('Given that loam exists', () => {
                     (result) => {
                         throw new Error(
                             'warp() promise should have been rejected but got ' +
+                            result + ' instead.'
+                        );
+                    },
+                    error => expect(error.message).to.include(
+                        'All items in the argument list must be strings'
+                    )
+                );
+        });
+    });
+
+    describe('calling rasterize with non-string arguments', function () {
+        it('should fail and return an error message', function () {
+            return loam.rasterize(geojson, ['-burn', 1, '-of', 'GTiff', '-ts', 10, 10])
+                .then(ds => ds.bytes()) // Need to call an accessor to trigger operation execution
+                .then(
+                    (result) => {
+                        throw new Error(
+                            'rasterize() promise should have been rejected but got ' +
                             result + ' instead.'
                         );
                     },

--- a/test/loam.spec.js
+++ b/test/loam.spec.js
@@ -175,20 +175,6 @@ describe('Given that loam exists', () => {
     /**
      * Failure cases
      **/
-    describe('calling open() on an invalid file', function () {
-        it('should fail and return an error message', function () {
-            return xhrAsPromiseBlob(invalidTifPath)
-                .then(garbage => loam.open(garbage))
-                .then(
-                    () => {
-                        throw new Error('GDALOpen promise should have been rejected');
-                    },
-                    error => expect(error.message).to.include(
-                        'not recognized as a supported file format'
-                    )
-                );
-        });
-    });
 
     describe('calling convert with invalid arguments', function () {
         it('should fail and return an error message', function () {


### PR DESCRIPTION
## Overview

This finishes and refactors the work started in #26 ; this is intended to supersede that PR but builds off of, and is targeted at, #41 instead. This adds a `loam.rasterize()` function that can be used to generate GeoTIFFs from GeoJSON in the browser.

## Testing Instructions

- The only testing I can think of that would be valuable beyond what CI provides would be to code up sample apps that exercise `pathPrefix` and `rasterize()` in a real app, and confirm that they both work as expected. However, that's a lot of work, so don't feel obligated to do that -- a read-through is enough, and I'll exercise this more fully when I start work on a showcase project for the release announcement.


## Checklist

- [x] Add entry to CHANGELOG.md
- [x] Update the README with any function signature changes

Will close #26 when merged.