### PR TITLE
Improve documentation for build tool integration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 ## Upcoming release
+- Improve documentation for integrating with build tools
 
 ## 1.0.0 (2021-03-17)
 - No changes from RC.2 except dependency updates

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ ln -s ../node_modules/gdal-js/gdal.wasm public/gdal.wasm
 ## Basic usage
 
 ```javascript
+import loam from "loam";
+
 // Load WebAssembly and data files asynchronously. Will be called automatically by loam.open()
 // but it is often helpful for responsiveness to pre-initialize because these files are fairly large. Returns a promise.
 loam.initialize();

--- a/README.md
+++ b/README.md
@@ -9,12 +9,29 @@ npm install loam
 
 Assuming you are using a build system, the main `loam` library should integrate into your build the same as any other library might. However, in order to correctly initialize the Emscripten environment for running GDAL, there are other assets that need to be accessible via HTTP request at runtime, but which should _not_ be included in the main application bundle. Specifically, these are:
 
-- `loam-worker.min.js`: This is the "backend" of the library; it initializes the Web Worker and translates between the Loam "frontend" and GDAL.
+- `loam-worker.js`: This is the "backend" of the library; it initializes the Web Worker and translates between the Loam "frontend" and GDAL.
 - [`gdal.js`](https://www.npmjs.com/package/gdal-js): This initializes the Emscripten runtime and loads the GDAL WebAssembly.
 - [`gdal.wasm`](https://www.npmjs.com/package/gdal-js): The GDAL binary, compiled to WebAssembly.
 - [`gdal.data`](https://www.npmjs.com/package/gdal-js): Contains configuration files that GDAL expects to find on the host filesystem.
 
-All of these files will be included in the `node_modules` folder after running `npm install loam`, but it is up to you to integrate them into your development environment and deployment processes.
+All of these files will be included in the `node_modules` folder after running `npm install loam`, but it is up to you to integrate them into your development environment and deployment processes. Unfortunately, support for WebAssembly and Web Workers is still relatively young, so many build tools do not yet have a straightforward out-of-the-box solution that will work. However, in general, treating the four files above similarly to static assets (e.g. images, videos, or PDFs) tends to work fairly well. An example for Create React App is given below.
+
+## Create React App
+When integrating Loam with a React app that was initialized using Create React App, the simplest thing to do is probably to copy the assets above into [the `/public` folder](https://create-react-app.dev/docs/using-the-public-folder#adding-assets-outside-of-the-module-system), like so:
+
+```
+cp node_modules/gdal-js/gdal.* node_modules/loam/lib/loam-worker.js public/
+```
+
+This will cause the CRA build system to copy these files into the build folder untouched, where they can then be accessed by URL (e.g. `http://localhost:3000/gdal.wasm`).
+However, this has the disadvantage that you will need to commit the copied files to source control, and they won't be updated if you update Loam. A way to work around this is to put symlinks in `/public` instead:
+
+```
+ln -s ../node_modules/loam/lib/loam-worker.js public/loam-worker.js
+ln -s ../node_modules/gdal-js/gdal.wasm public/gdal.wasm
+ln -s ../node_modules/gdal-js/gdal.data public/gdal.data
+ln -s ../node_modules/gdal-js/gdal.wasm public/gdal.wasm
+```
 
 # API Documentation
 ## Basic usage


### PR DESCRIPTION
## Overview

Fleshes out the documentation to include more information on how to integrate Loam with build tooling, which has been a common pain-point for users. Includes an explicit example for create-react-app, since it's what we often use and is fairly popular.

### Notes

Build tooling support for WebAssembly and Web Workers is astonishingly poor right now, and it's even worse for libraries because you can't rely on any specific build tool or version of a build tool being available. There are decent solutions for developers who are writing and managing their own Web Workers and/or WebAssembly within their own app, but I haven't found much help if you want to integrate _3rd-party_ Web Workers or WebAssembly into an app, which is what Loam essentially asks developers to do.

It seems like the build story would be much easier if Loam didn't provide a web-worker-based API, and forced developers to figure that part out themselves, but you'll almost always want to run GDAL on a separate thread, so that would in effect force every developer to re-invent roughly the same Web Worker communication code (or copy-paste a "blessed" template file into their project source). That seems even worse than the current problems with build tool integration, which make things kind of clunky but aren't insurmountable obstacles.

Hopefully improving the documentation, plus addressing #71 and #58, will smooth off enough rough edges that we can sit tight until the rest of the ecosystem catches up, but if there are any other approaches that I'm not thinking of, I'd love to hear them!

## Testing Instructions

 * Read through the instructions and make sure they're clear.
 * Spin up a tiny create-react-app ... app and make sure the instructions work for you. Once you've followed the instructions, putting something like this inside App.js() should be all that's needed:
```javascript
import logo from './logo.svg';
import './App.css';
import { useEffect, useState } from 'react';
import loam from 'loam'

function App() {
  const [loamStatus, setLoamStatus] = useState("not ready yet.");

  useEffect(() => {
    loam.initialize("/").then(() => setLoamStatus("ready!"));
  }, []);

  return (
    <div className="App">
      <header className="App-header">
        <img src={logo} className="App-logo" alt="logo" />
        <p>
          Loam is {loamStatus}
        </p>
      </header>
    </div>
  );
}

export default App;
```

## Checklist

- [x] Add entry to CHANGELOG.md
- [x] Update the README with any function signature changes

Resolves #68 and/or #62 (both of which were closed by their creators, but hopefully this will prevent other people from having similar trouble).
