### PR TITLE
Add .bytes() method to the README

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 ## Upcoming
+- Document bytes() method
 
 ## 1.1.0 (2021-09-29)
 - Improve documentation for integrating with build tools

--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ A promise which resolves to the affine transform.
 
 <br />
 
+### `GDALDataset.bytes()`
+Get the on-disk representation of the dataset, as an array of bytes.
+#### Return value
+A promise which resolves to a Uint8Array containing the bytes of the dataset.
+
+<br />
+
 ### `GDALDataset.convert(args)`
 Converts raster data between different formats. This is the equivalent of the [gdal_translate](https://gdal.org/programs/gdal_translate.html) command.
 


### PR DESCRIPTION
## Overview

The `bytes()` method is pretty important because without it there's no way to get any actual files out of GDAL, but it was missing from the README. 🤦 This adds it.

## Testing Instructions

 * Read the addition to the README and make sure it's clear and isn't missing anything.

## Checklist

- [x] Add entry to CHANGELOG.md
- [x] Update the README with any function signature changes

Resolves #87 
