### PR TITLE
Raster band wrappers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - Add support for opening vector datasets
 - Add GDALDataset.layerCount() to wrap GDALDatasetGetLayerCount()
 - Add GDALDataset.vectorConvert() to wrap GDALVectorTranslate()
+- Add wrappers for GDALGetRasterMinimum, GDALGetRasterMaximum, GDALGetRasterDataType, GDALGetRasterStatistics, and GDALGetRasterNoDataValue
 
 ## 1.1.2 (2022-10-12)
 - Allow users to specify a valid absolute URL when the default URL is invalid

--- a/README.md
+++ b/README.md
@@ -159,6 +159,59 @@ A promise which resolves to the affine transform.
 
 <br />
 
+### `GDALDataset.bandMinimum(bandNum)`
+Get the actual minimum value or the minimum possible value of a band (depending on format).
+#### Parameters
+- `bandNum`: The number of the band for which to get the minimum value. Band numbering starts at 1.
+#### Return value
+A promise which resolves to a minimum value for the specified band.
+
+<br />
+
+### `GDALDataset.bandMaximum(bandNum)`
+Get the actual maximum value or the maximum possible value of a band (depending on format).
+#### Parameters
+- `bandNum`: The number of the band for which to get the maximum value. Band numbering starts at 1.
+#### Return value
+A promise which resolves to a maximum value for the specified band.
+
+<br />
+
+### `GDALDataset.bandStatistics(bandNum)`
+Get statistics about the values in a band.
+#### Parameters
+- `bandNum`: The number of the band for which to get statistics. Band numbering starts at 1.
+#### Return value
+A promise which resolves to an object containing statistics. The shape of the object will be:
+```javascript
+{
+  minimum: The calculated minimum value of the band
+  maximum: The calculated minimum value of the band
+  median: The calculated median value of the band
+  stdDev: The calculated standard deviation of the band
+}
+```
+
+<br />
+
+### `GDALDataset.bandNoDataValue(bandNum)`
+Get the value representing "no data" within the band.
+#### Parameters
+- `bandNum`: The number of the band for which to get the no-data value. Band numbering starts at 1.
+#### Return value
+A promise which resolves to the no-data value for the specified band.
+
+<br />
+
+### `GDALDataset.bandDataType(bandNum)`
+Get the data type of the band (Byte, UInt16, Float32, etc.)
+#### Parameters
+- `bandNum`: The number of the band for which to get the data type. Band numbering starts at 1.
+#### Return value
+A promise which resolves to a string containing the name of the data type for the specified band. For example, 'Byte', 'Float32', etc.
+
+<br />
+
 ### `GDALDataset.bytes()`
 Get the on-disk representation of the dataset, as an array of bytes.
 #### Return value

--- a/demo/index.js
+++ b/demo/index.js
@@ -58,6 +58,15 @@ function displayInfo() {
                         ')\n';
                 });
             });
+
+            if (count > 0) {
+                ds.bandStatistics(1).then((stats) => {
+                    displayElem.innerText += 'Band 1 min: ' + stats.minimum + '\n';
+                    displayElem.innerText += 'Band 1 max: ' + stats.maximum + '\n';
+                    displayElem.innerText += 'Band 1 median: ' + stats.median + '\n';
+                    displayElem.innerText += 'Band 1 standard deviation: ' + stats.stdDev + '\n';
+                });
+            }
         });
     });
 }

--- a/src/gdalDataType.js
+++ b/src/gdalDataType.js
@@ -1,0 +1,19 @@
+// In order to make enums available from JS it's necessary to use embind, which seems like
+// overkill for something this small. This replicates the GDALDataType enum:
+// https://gdal.org/api/raster_c_api.html#_CPPv412GDALDataType and will need to be changed
+// if that enum changes. There is a smoke test that should warn us if it changes upstream.
+export const GDALDataTypes = [
+    'Unknown',
+    'Byte',
+    'UInt16',
+    'Int16',
+    'UInt32',
+    'Int32',
+    'Float32',
+    'Float64',
+    'CInt16',
+    'CInt32',
+    'CFloat32',
+    'CFloat64',
+    'TypeCount',
+];

--- a/src/gdalDataset.js
+++ b/src/gdalDataset.js
@@ -68,6 +68,26 @@ export class GDALDataset {
         return accessFromDataset('GDALGetGeoTransform', this);
     }
 
+    bandMinimum(bandNum) {
+        return accessFromDataset('GDALGetRasterMinimum', this, bandNum);
+    }
+
+    bandMaximum(bandNum) {
+        return accessFromDataset('GDALGetRasterMaximum', this, bandNum);
+    }
+
+    bandStatistics(bandNum) {
+        return accessFromDataset('GDALGetRasterStatistics', this, bandNum);
+    }
+
+    bandDataType(bandNum) {
+        return accessFromDataset('GDALGetRasterDataType', this, bandNum);
+    }
+
+    bandNoDataValue(bandNum) {
+        return accessFromDataset('GDALGetRasterNoDataValue', this, bandNum);
+    }
+
     convert(args) {
         return new Promise((resolve, reject) => {
             resolve(

--- a/src/worker.js
+++ b/src/worker.js
@@ -11,6 +11,11 @@ import wGDALDEMProcessing from './wrappers/gdalDemProcessing.js';
 import wGDALGetRasterCount from './wrappers/gdalGetRasterCount.js';
 import wGDALGetRasterXSize from './wrappers/gdalGetRasterXSize.js';
 import wGDALGetRasterYSize from './wrappers/gdalGetRasterYSize.js';
+import wGDALGetRasterMinimum from './wrappers/gdalGetRasterMinimum.js';
+import wGDALGetRasterMaximum from './wrappers/gdalGetRasterMaximum.js';
+import wGDALGetRasterNoDataValue from './wrappers/gdalGetRasterNoDataValue.js';
+import wGDALGetRasterDataType from './wrappers/gdalGetRasterDataType.js';
+import wGDALGetRasterStatistics from './wrappers/gdalGetRasterStatistics.js';
 import wGDALGetProjectionRef from './wrappers/gdalGetProjectionRef.js';
 import wGDALGetGeoTransform from './wrappers/gdalGetGeoTransform.js';
 import wGDALTranslate from './wrappers/gdalTranslate.js';
@@ -117,6 +122,26 @@ self.Module = {
             self.Module.cwrap('GDALGetRasterYSize', 'number', ['number']),
             errorHandling
         );
+        registry.GDALGetRasterMinimum = wGDALGetRasterMinimum(
+            self.Module.cwrap('GDALGetRasterMinimum', 'number', ['number']),
+            errorHandling
+        );
+        registry.GDALGetRasterMaximum = wGDALGetRasterMaximum(
+            self.Module.cwrap('GDALGetRasterMaximum', 'number', ['number']),
+            errorHandling
+        );
+        registry.GDALGetRasterNoDataValue = wGDALGetRasterNoDataValue(
+            self.Module.cwrap('GDALGetRasterNoDataValue', 'number', ['number']),
+            errorHandling
+        );
+        registry.GDALGetRasterDataType = wGDALGetRasterDataType(
+            self.Module.cwrap('GDALGetRasterDataType', 'number', ['number']),
+            errorHandling
+        );
+        registry.GDALGetRasterStatistics = wGDALGetRasterStatistics(
+            self.Module.cwrap('GDALGetRasterStatistics', 'number', ['number']),
+            errorHandling
+        );
         registry.GDALGetProjectionRef = wGDALGetProjectionRef(
             self.Module.cwrap('GDALGetProjectionRef', 'string', ['number']),
             errorHandling
@@ -193,7 +218,7 @@ self.Module = {
     },
 };
 
-function handleDatasetAccess(accessor, dataset) {
+function handleDatasetAccess(accessor, dataset, args) {
     // 1: Open the source.
     let srcDs = registry[dataset.source.func](
         dataset.source.src,
@@ -225,7 +250,7 @@ function handleDatasetAccess(accessor, dataset) {
             true
         );
     } else if (accessor) {
-        result = registry[accessor](resultDs.datasetPtr);
+        result = registry[accessor](resultDs.datasetPtr, ...args);
         registry.GDALClose(resultDs.datasetPtr, resultDs.directory, resultDs.filePath, false);
     } else {
         registry.GDALClose(resultDs.datasetPtr, resultDs.directory, resultDs.filePath, false);
@@ -256,7 +281,7 @@ onmessage = function (msg) {
         if ('func' in msg.data && 'args' in msg.data) {
             result = handleFunctionCall(msg.data.func, msg.data.args);
         } else if ('accessor' in msg.data && 'dataset' in msg.data) {
-            result = handleDatasetAccess(msg.data.accessor, msg.data.dataset);
+            result = handleDatasetAccess(msg.data.accessor, msg.data.dataset, msg.data.args);
         } else {
             postMessage({
                 success: false,

--- a/src/workerCommunication.js
+++ b/src/workerCommunication.js
@@ -172,8 +172,8 @@ function workerTaskPromise(options) {
 }
 
 // Accessors is a list of accessors operations to run on the dataset defined by dataset.
-function accessFromDataset(accessor, dataset) {
-    return workerTaskPromise({ accessor: accessor, dataset: dataset });
+function accessFromDataset(accessor, dataset, ...otherArgs) {
+    return workerTaskPromise({ accessor: accessor, dataset: dataset, args: otherArgs });
 }
 
 // Run a single function on the worker.

--- a/src/wrappers/gdalGetRasterDataType.js
+++ b/src/wrappers/gdalGetRasterDataType.js
@@ -1,0 +1,31 @@
+import { GDALDataTypes } from '../gdalDataType.js';
+
+/* global Module */
+export default function (GDALGetRasterDataType, errorHandling) {
+    return function (datasetPtr, bandNum) {
+        const bandPtr = Module.ccall(
+            'GDALGetRasterBand',
+            'number',
+            ['number', 'number'],
+            [datasetPtr, bandNum]
+        );
+        // GDALGetRasterDataType will provide an integer because it's pulling from an enum
+        // So we use that to index into an array of the corresponding type strings so that it's
+        // easier to work with from Javascript land.
+        const result = GDALDataTypes[GDALGetRasterDataType(bandPtr)];
+
+        const errorType = errorHandling.CPLGetLastErrorType();
+
+        // Check for errors; clean up and throw if error is detected
+        if (
+            errorType === errorHandling.CPLErr.CEFailure ||
+            errorType === errorHandling.CPLErr.CEFatal
+        ) {
+            throw new Error(
+                'Error in GDALGetRasterDataType: ' + errorHandling.CPLGetLastErrorMsg()
+            );
+        } else {
+            return result;
+        }
+    };
+}

--- a/src/wrappers/gdalGetRasterMaximum.js
+++ b/src/wrappers/gdalGetRasterMaximum.js
@@ -1,0 +1,24 @@
+/* global Module */
+export default function (GDALGetRasterMaximum, errorHandling) {
+    return function (datasetPtr, bandNum) {
+        const bandPtr = Module.ccall(
+            'GDALGetRasterBand',
+            'number',
+            ['number', 'number'],
+            [datasetPtr, bandNum]
+        );
+        const result = GDALGetRasterMaximum(bandPtr);
+
+        const errorType = errorHandling.CPLGetLastErrorType();
+
+        // Check for errors; clean up and throw if error is detected
+        if (
+            errorType === errorHandling.CPLErr.CEFailure ||
+            errorType === errorHandling.CPLErr.CEFatal
+        ) {
+            throw new Error('Error in GDALGetRasterMaximum: ' + errorHandling.CPLGetLastErrorMsg());
+        } else {
+            return result;
+        }
+    };
+}

--- a/src/wrappers/gdalGetRasterMinimum.js
+++ b/src/wrappers/gdalGetRasterMinimum.js
@@ -1,0 +1,24 @@
+/* global Module */
+export default function (GDALGetRasterMinimum, errorHandling) {
+    return function (datasetPtr, bandNum) {
+        const bandPtr = Module.ccall(
+            'GDALGetRasterBand',
+            'number',
+            ['number', 'number'],
+            [datasetPtr, bandNum]
+        );
+        const result = GDALGetRasterMinimum(bandPtr);
+
+        const errorType = errorHandling.CPLGetLastErrorType();
+
+        // Check for errors; clean up and throw if error is detected
+        if (
+            errorType === errorHandling.CPLErr.CEFailure ||
+            errorType === errorHandling.CPLErr.CEFatal
+        ) {
+            throw new Error('Error in GDALGetRasterMinimum: ' + errorHandling.CPLGetLastErrorMsg());
+        } else {
+            return result;
+        }
+    };
+}

--- a/src/wrappers/gdalGetRasterNoDataValue.js
+++ b/src/wrappers/gdalGetRasterNoDataValue.js
@@ -1,0 +1,26 @@
+/* global Module */
+export default function (GDALGetRasterNoDataValue, errorHandling) {
+    return function (datasetPtr, bandNum) {
+        const bandPtr = Module.ccall(
+            'GDALGetRasterBand',
+            'number',
+            ['number', 'number'],
+            [datasetPtr, bandNum]
+        );
+        const result = GDALGetRasterNoDataValue(bandPtr);
+
+        const errorType = errorHandling.CPLGetLastErrorType();
+
+        // Check for errors; clean up and throw if error is detected
+        if (
+            errorType === errorHandling.CPLErr.CEFailure ||
+            errorType === errorHandling.CPLErr.CEFatal
+        ) {
+            throw new Error(
+                'Error in GDALGetRasterNoDataValue: ' + errorHandling.CPLGetLastErrorMsg()
+            );
+        } else {
+            return result;
+        }
+    };
+}

--- a/src/wrappers/gdalGetRasterStatistics.js
+++ b/src/wrappers/gdalGetRasterStatistics.js
@@ -1,0 +1,56 @@
+/* global Module */
+export default function (GDALGetRasterStatistics, errorHandling) {
+    return function (datasetPtr, bandNum) {
+        const bandPtr = Module.ccall(
+            'GDALGetRasterBand',
+            'number',
+            ['number', 'number'],
+            [datasetPtr, bandNum]
+        );
+        // We need to allocate pointers to store statistics into which will get passed into
+        // GDALGetRasterStatistics(). They're all doubles, so allocate 8 bytes each.
+        const minPtr = Module._malloc(8);
+        const maxPtr = Module._malloc(8);
+        const meanPtr = Module._malloc(8);
+        const sdPtr = Module._malloc(8);
+        const returnErr = GDALGetRasterStatistics(
+            bandPtr,
+            0, // Approximate statistics flag -- set to false
+            1, // Force flag -- will always return statistics even if image must be rescanned
+            minPtr,
+            maxPtr,
+            meanPtr,
+            sdPtr
+        );
+
+        const errorType = errorHandling.CPLGetLastErrorType();
+
+        // Check for errors; throw if error is detected
+        // GDALGetRasterStatistics returns CE_Failure if an error occurs.
+        try {
+            if (
+                errorType === errorHandling.CPLErr.CEFailure ||
+                errorType === errorHandling.CPLErr.CEFatal ||
+                returnErr === errorHandling.CPLErr.CEFailure
+            ) {
+                throw new Error(
+                    'Error in GDALGetRasterStatistics: ' + errorHandling.CPLGetLastErrorMsg()
+                );
+            } else {
+                // At this point the values at each pointer should have been written with statistics
+                // so we can read them out and send them back.
+                return {
+                    minimum: Module.getValue(minPtr, 'double'),
+                    maximum: Module.getValue(maxPtr, 'double'),
+                    median: Module.getValue(meanPtr, 'double'),
+                    stdDev: Module.getValue(sdPtr, 'double'),
+                };
+            }
+        } finally {
+            Module._free(minPtr);
+            Module._free(maxPtr);
+            Module._free(meanPtr);
+            Module._free(sdPtr);
+        }
+    };
+}


### PR DESCRIPTION
## Overview
Add wrappers for some GDALRasterBand methods, specifically
- GDALGetRasterDataType
- GDALGetRasterMaximum
- GDALGetRasterMinimum
- GDALGetRasterNoDataValue
- GDALGetRasterStatistics

These methods require the band number to be passed when called, e.g. ds.bandMaximum(1).

### Demo
Added band statistics at the bottom:

![Screenshot from 2022-12-02 10-26-58](https://user-images.githubusercontent.com/447977/205327956-56551884-a83f-4eb6-8f9e-3f96c9c4e55f.png)

### Notes

I'm interested to hear thoughts on the interface here. I had initially planned to go with the interface discussed in https://github.com/azavea/loam/issues/81#issuecomment-915206788, but as I got into implementation, that approach would have added complexity and I became less and less confident that I would prefer it as a library user. It would make multiple calls to the same band smoother because it gives you a band object you can hold onto for repeat access to the same band, but it would make calling the same method on multiple bands clunkier because each different band you access requires two steps rather than one (`getBand(num).then(band => band.getWhatever())` as compared to `ds.bandGetWhatever(bandNum)`).

I went with the approach here because it was pretty simple to implement, and we can build on it to implement the other interface later if we want to. For example, a hypothetical `getBand()` function could be implemented inside `gdalDataset.js` as something like the below (though I've ignored promises):

```javascript
getBand(bandNum) {
  return {
    getMax: () => accessFromDataset('GDALGetRasterMaximum', this, bandNum);
    // etc.
  }
}
```

## Testing Instructions

 * Run tests
 * Check some rasters in the demo site (`yarn run demo` and then go to `localhost:8080`) and confirm the stats match the information provided by `gdalinfo -stats` on the command line.


## Checklist

- [x] Add entry to CHANGELOG.md
- [x] Update the README with any function signature changes

Resolves #81